### PR TITLE
add siblings unit test

### DIFF
--- a/tests/cases/dom/traverse/siblings.js
+++ b/tests/cases/dom/traverse/siblings.js
@@ -1,0 +1,77 @@
+QUnit.module(
+    "siblings()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element-find element1"></div>' +
+                '<div class="test-element-find element2">'+
+                    '<div class="test-element-find element2-1"></div>' +
+                '</div>' +
+                'Some text' +
+                '<div class="test-element-find element3"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "siblings() with an element in the middle",
+    function (assert)
+    {
+        const siblings = mojave.dom.traverse.siblings;
+        const element = document.querySelector(".test-element-find.element2");
+
+        const result = siblings(element);
+
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element1"), "contains .element1");
+        assert.ok(result[0].classList.contains("element3"), "contains .element3");
+    }
+);
+
+
+QUnit.test(
+    "siblings() with an element at the start",
+    function (assert)
+    {
+        const siblings = mojave.dom.traverse.siblings;
+        const element = document.querySelector(".test-element-find.element1");
+
+        const result = siblings(element);
+
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element2"), "contains .element2");
+        assert.ok(result[0].classList.contains("element3"), "contains .element3");
+    }
+);
+
+
+QUnit.test(
+    "siblings() with an element at the end",
+    function (assert)
+    {
+        const siblings = mojave.dom.traverse.siblings;
+        const element = document.querySelector(".test-element-find.element3");
+
+        const result = siblings(element);
+
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element1"), "contains .element1");
+        assert.ok(result[0].classList.contains("element2"), "contains .element2");
+    }
+);
+
+
+QUnit.test(
+    "siblings() with an element without siblings",
+    function (assert)
+    {
+        const siblings = mojave.dom.traverse.siblings;
+        const element = document.querySelector(".test-element-find.element2-1");
+
+        const result = siblings(element);
+
+        assert.equal(result.length, 0, "found no elements");
+    }
+);


### PR DESCRIPTION
## Unit tests

- `siblings()` with an element in the middle
- `siblings()` with an element at the start
- `siblings()` with an element at the end
- `siblings()` with an element without siblings

## Expected results (tests 1-3)
`siblings(element2)` should return sibling elements1 and elements3

## Current results (tests 1-3)
`siblings(element2)` is returning the requested element2 as many times as there are siblings (in these particular tests 2)

![mojave results](https://user-images.githubusercontent.com/984069/27688462-efa74eae-5cda-11e7-97e0-86654a9d2ba9.png)