### PR TITLE
next/nextAll and prev/prevAll unit tests

### DIFF
--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -28,7 +28,7 @@ QUnit.test(
         const result = next(element);
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.found("element3"), "found .element3");
+        assert.ok(result.classList.contains("element3"), "found .element3");
     }
 );
 
@@ -57,6 +57,6 @@ QUnit.test(
         const result = next(element, ".element3");
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.found("element3"), "found .element3");
+        assert.ok(result.classList.contains("element3"), "found .element3");
     }
 );

--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -1,0 +1,57 @@
+QUnit.module(
+    "next()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element-next element1"></div>' +
+                '<div class="test-element-next element2"></div>' +
+                'Some text' +
+                '<div class="test-element-next element3"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "next() with an element in the middle, without selector",
+    function (assert)
+    {
+        const next = mojave.dom.traverse.next;
+        const element = document.querySelector(".test-element-next.element2");
+
+        const result = next(element);
+
+        assert.ok(result, "found 1 element");
+        assert.ok(result.classList.contains("element3"), "contains .element3");
+    }
+);
+
+
+QUnit.test(
+    "next() with an element at the end, without selector",
+    function (assert)
+    {
+        const next = mojave.dom.traverse.next;
+        const element = document.querySelector(".test-element-next.element3");
+
+        const result = next(element);
+
+        assert.notOk(result, "found 0 elements");
+    }
+);
+
+
+QUnit.test(
+    "next() with an element at the start, with selector",
+    function (assert)
+    {
+        const next = mojave.dom.traverse.next;
+        const element = document.querySelector(".test-element-next.element1");
+
+        const result = next(element, ".element3");
+
+        assert.ok(result, "found 1 element");
+        assert.ok(result.classList.contains("element3"), "contains .element3");
+    }
+);

--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -42,7 +42,7 @@ QUnit.test(
 
         const result = next(element);
 
-        assert.notOk(result, "found 0 elements");
+        assert.ok(null === result, "found 0 elements");
     }
 );
 

--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -4,15 +4,15 @@ QUnit.module(
         beforeEach: function ()
         {
             document.getElementById("qunit-fixture").innerHTML =
-                '<div class="test-element-next element1"></div>' +
-                '<div class="test-element-next element2">'+
-                    '<div class="test-element-next element2-1"></div>' +
+                '<div class="test-element element1"></div>' +
+                '<div class="test-element element2">'+
+                    '<div class="test-element element2-1"></div>' +
                 '</div>' +
                 'Some text' +
-                '<div class="test-element-next element3"></div>' +
-                '<div class="test-element-next element4"></div>' +
-                '<div class="test-element-next element5"></div>' +
-                '<div class="test-element-next element6"></div>';
+                '<div class="test-element element3"></div>' +
+                '<div class="test-element element4"></div>' +
+                '<div class="test-element element5"></div>' +
+                '<div class="test-element element6"></div>';
         }
     }
 );
@@ -23,12 +23,12 @@ QUnit.test(
     function (assert)
     {
         const next = mojave.dom.traverse.next;
-        const element = document.querySelector(".test-element-next.element2");
+        const element = document.querySelector(".element2");
 
         const result = next(element);
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element3"), "contains .element3");
+        assert.ok(result.classList.found("element3"), "found .element3");
     }
 );
 
@@ -38,7 +38,7 @@ QUnit.test(
     function (assert)
     {
         const next = mojave.dom.traverse.next;
-        const element = document.querySelector(".test-element-next.element6");
+        const element = document.querySelector(".element6");
 
         const result = next(element);
 
@@ -52,11 +52,11 @@ QUnit.test(
     function (assert)
     {
         const next = mojave.dom.traverse.next;
-        const element = document.querySelector(".test-element-next.element1");
+        const element = document.querySelector(".element1");
 
         const result = next(element, ".element3");
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element3"), "contains .element3");
+        assert.ok(result.classList.found("element3"), "found .element3");
     }
 );

--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -5,9 +5,14 @@ QUnit.module(
         {
             document.getElementById("qunit-fixture").innerHTML =
                 '<div class="test-element-next element1"></div>' +
-                '<div class="test-element-next element2"></div>' +
+                '<div class="test-element-next element2">'+
+                    '<div class="test-element-next element2-1"></div>' +
+                '</div>' +
                 'Some text' +
-                '<div class="test-element-next element3"></div>';
+                '<div class="test-element-next element3"></div>' +
+                '<div class="test-element-next element4"></div>' +
+                '<div class="test-element-next element5"></div>' +
+                '<div class="test-element-next element6"></div>';
         }
     }
 );
@@ -33,7 +38,7 @@ QUnit.test(
     function (assert)
     {
         const next = mojave.dom.traverse.next;
-        const element = document.querySelector(".test-element-next.element3");
+        const element = document.querySelector(".test-element-next.element6");
 
         const result = next(element);
 

--- a/tests/cases/dom/traverse/nextAll.js
+++ b/tests/cases/dom/traverse/nextAll.js
@@ -4,15 +4,15 @@ QUnit.module(
         beforeEach: function ()
         {
             document.getElementById("qunit-fixture").innerHTML =
-                '<div class="test-element-nextAll element1"></div>' +
-                '<div class="test-element-nextAll test-class-nextAll element2">' +
-                    '<div class="test-element-nextAll element2-1"></div>' +
+                '<div class="test-element element1"></div>' +
+                '<div class="test-element test-class element2">' +
+                    '<div class="test-element element2-1"></div>' +
                 '</div>' +
                 'Some text' +
-                '<div class="test-element-nextAll test-class-nextAll element3"></div>' +
-                '<div class="test-element-nextAll element4"></div>' +
-                '<div class="test-element-nextAll element5"></div>' +
-                '<div class="test-element-nextAll element6"></div>';
+                '<div class="test-element test-class element3"></div>' +
+                '<div class="test-element element4"></div>' +
+                '<div class="test-element element5"></div>' +
+                '<div class="test-element element6"></div>';
         }
     }
 );
@@ -23,13 +23,13 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element4");
+        const element = document.querySelector(".element4");
 
         const result = nextAll(element);
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.contains("element5"), "contains .element5");
-        assert.ok(result[1].classList.contains("element6"), "contains .element6");
+        assert.ok(result[0].classList.found("element5"), "found .element5");
+        assert.ok(result[1].classList.found("element6"), "found .element6");
     }
 );
 
@@ -39,16 +39,16 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element1");
+        const element = document.querySelector(".element1");
 
         const result = nextAll(element);
 
         assert.equal(result.length, 5, "found 5 elements");
-        assert.ok(result[0].classList.contains("element2"), "contains .element2");
-        assert.ok(result[1].classList.contains("element3"), "contains .element3");
-        assert.ok(result[2].classList.contains("element4"), "contains .element4");
-        assert.ok(result[3].classList.contains("element5"), "contains .element5");
-        assert.ok(result[4].classList.contains("element6"), "contains .element6");
+        assert.ok(result[0].classList.found("element2"), "found .element2");
+        assert.ok(result[1].classList.found("element3"), "found .element3");
+        assert.ok(result[2].classList.found("element4"), "found .element4");
+        assert.ok(result[3].classList.found("element5"), "found .element5");
+        assert.ok(result[4].classList.found("element6"), "found .element6");
     }
 );
 
@@ -58,7 +58,7 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element6");
+        const element = document.querySelector(".element6");
 
         const result = nextAll(element);
 
@@ -73,12 +73,12 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element1");
+        const element = document.querySelector(".element1");
 
-        const result = nextAll(element, ".test-class-nextAll");
+        const result = nextAll(element, ".test-class");
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.contains("element2"), "contains .element2");
-        assert.ok(result[1].classList.contains("element3"), "contains .element3");
+        assert.ok(result[0].classList.found("element2"), "found .element2");
+        assert.ok(result[1].classList.found("element3"), "found .element3");
     }
 );

--- a/tests/cases/dom/traverse/nextAll.js
+++ b/tests/cases/dom/traverse/nextAll.js
@@ -1,0 +1,78 @@
+QUnit.module(
+    "nextAll()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element-nextAll element1"></div>' +
+                '<div class="test-element-nextAll test-class-nextAll element2"></div>' +
+                'Some text' +
+                '<div class="test-element-nextAll test-class-nextAll element3"></div>' +
+                '<div class="test-element-nextAll element4"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "nextAll() with an element in the middle, without selector",
+    function (assert)
+    {
+        const nextAll = mojave.dom.traverse.nextAll;
+        const element = document.querySelector(".test-element-nextAll.element2");
+
+        const result = nextAll(element);
+
+        assert.equal(result.length, 2, "found 2 element");
+        assert.ok(result[0].classList.contains("element3"), "contains .element3");
+        assert.ok(result[1].classList.contains("element4"), "contains .element4");
+    }
+);
+
+
+QUnit.test(
+    "nextAll() with an element at the start, without selector",
+    function (assert)
+    {
+        const nextAll = mojave.dom.traverse.nextAll;
+        const element = document.querySelector(".test-element-nextAll.element1");
+
+        const result = nextAll(element);
+
+        assert.equal(result.length, 3, "found 3 elements");
+        assert.ok(result[0].classList.contains("element2"), "contains .element2");
+        assert.ok(result[1].classList.contains("element3"), "contains .element3");
+        assert.ok(result[2].classList.contains("element4"), "contains .element4");
+    }
+);
+
+
+QUnit.test(
+    "nextAll() with an element at the end, without selector",
+    function (assert)
+    {
+        const nextAll = mojave.dom.traverse.nextAll;
+        const element = document.querySelector(".test-element-nextAll.element4");
+
+        const result = nextAll(element);
+
+        assert.equal(result.length, 0, "found 0 elements");
+    }
+);
+
+
+
+QUnit.test(
+    "nextAll() with an element at the start, with selector",
+    function (assert)
+    {
+        const nextAll = mojave.dom.traverse.nextAll;
+        const element = document.querySelector(".test-element-nextAll.element1");
+
+        const result = nextAll(element, ".test-class-nextAll");
+
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element2"), "contains .element2");
+        assert.ok(result[1].classList.contains("element3"), "contains .element3");
+    }
+);

--- a/tests/cases/dom/traverse/nextAll.js
+++ b/tests/cases/dom/traverse/nextAll.js
@@ -5,10 +5,14 @@ QUnit.module(
         {
             document.getElementById("qunit-fixture").innerHTML =
                 '<div class="test-element-nextAll element1"></div>' +
-                '<div class="test-element-nextAll test-class-nextAll element2"></div>' +
+                '<div class="test-element-nextAll test-class-nextAll element2">' +
+                    '<div class="test-element-nextAll element2-1"></div>' +
+                '</div>' +
                 'Some text' +
                 '<div class="test-element-nextAll test-class-nextAll element3"></div>' +
-                '<div class="test-element-nextAll element4"></div>';
+                '<div class="test-element-nextAll element4"></div>' +
+                '<div class="test-element-nextAll element5"></div>' +
+                '<div class="test-element-nextAll element6"></div>';
         }
     }
 );
@@ -19,13 +23,13 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element2");
+        const element = document.querySelector(".test-element-nextAll.element4");
 
         const result = nextAll(element);
 
-        assert.equal(result.length, 2, "found 2 element");
-        assert.ok(result[0].classList.contains("element3"), "contains .element3");
-        assert.ok(result[1].classList.contains("element4"), "contains .element4");
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element5"), "contains .element5");
+        assert.ok(result[1].classList.contains("element6"), "contains .element6");
     }
 );
 
@@ -39,10 +43,12 @@ QUnit.test(
 
         const result = nextAll(element);
 
-        assert.equal(result.length, 3, "found 3 elements");
+        assert.equal(result.length, 5, "found 5 elements");
         assert.ok(result[0].classList.contains("element2"), "contains .element2");
         assert.ok(result[1].classList.contains("element3"), "contains .element3");
         assert.ok(result[2].classList.contains("element4"), "contains .element4");
+        assert.ok(result[3].classList.contains("element5"), "contains .element5");
+        assert.ok(result[4].classList.contains("element6"), "contains .element6");
     }
 );
 
@@ -52,7 +58,7 @@ QUnit.test(
     function (assert)
     {
         const nextAll = mojave.dom.traverse.nextAll;
-        const element = document.querySelector(".test-element-nextAll.element4");
+        const element = document.querySelector(".test-element-nextAll.element6");
 
         const result = nextAll(element);
 

--- a/tests/cases/dom/traverse/nextAll.js
+++ b/tests/cases/dom/traverse/nextAll.js
@@ -28,8 +28,8 @@ QUnit.test(
         const result = nextAll(element);
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.found("element5"), "found .element5");
-        assert.ok(result[1].classList.found("element6"), "found .element6");
+        assert.ok(result[0].classList.contains("element5"), "found .element5");
+        assert.ok(result[1].classList.contains("element6"), "found .element6");
     }
 );
 
@@ -44,11 +44,11 @@ QUnit.test(
         const result = nextAll(element);
 
         assert.equal(result.length, 5, "found 5 elements");
-        assert.ok(result[0].classList.found("element2"), "found .element2");
-        assert.ok(result[1].classList.found("element3"), "found .element3");
-        assert.ok(result[2].classList.found("element4"), "found .element4");
-        assert.ok(result[3].classList.found("element5"), "found .element5");
-        assert.ok(result[4].classList.found("element6"), "found .element6");
+        assert.ok(result[0].classList.contains("element2"), "found .element2");
+        assert.ok(result[1].classList.contains("element3"), "found .element3");
+        assert.ok(result[2].classList.contains("element4"), "found .element4");
+        assert.ok(result[3].classList.contains("element5"), "found .element5");
+        assert.ok(result[4].classList.contains("element6"), "found .element6");
     }
 );
 
@@ -78,7 +78,7 @@ QUnit.test(
         const result = nextAll(element, ".test-class");
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.found("element2"), "found .element2");
-        assert.ok(result[1].classList.found("element3"), "found .element3");
+        assert.ok(result[0].classList.contains("element2"), "found .element2");
+        assert.ok(result[1].classList.contains("element3"), "found .element3");
     }
 );

--- a/tests/cases/dom/traverse/prev.js
+++ b/tests/cases/dom/traverse/prev.js
@@ -4,15 +4,15 @@ QUnit.module(
         beforeEach: function ()
         {
             document.getElementById("qunit-fixture").innerHTML =
-                '<div class="test-element-prev element1"></div>' +
-                '<div class="test-element-prev element2">'+
-                    '<div class="test-element-prev element2-1"></div>' +
+                '<div class="test-element element1"></div>' +
+                '<div class="test-element element2">'+
+                    '<div class="test-element element2-1"></div>' +
                 '</div>' +
                 'Some text' +
-                '<div class="test-element-prev element3"></div>' +
-                '<div class="test-element-prev element4"></div>' +
-                '<div class="test-element-prev element5"></div>' +
-                '<div class="test-element-prev element6"></div>';
+                '<div class="test-element element3"></div>' +
+                '<div class="test-element element4"></div>' +
+                '<div class="test-element element5"></div>' +
+                '<div class="test-element element6"></div>';
         }
     }
 );
@@ -23,12 +23,12 @@ QUnit.test(
     function (assert)
     {
         const prev = mojave.dom.traverse.prev;
-        const element = document.querySelector(".test-element-prev.element3");
+        const element = document.querySelector(".element3");
 
         const result = prev(element);
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element2"), "contains .element2");
+        assert.ok(result.classList.found("element2"), "found .element2");
     }
 );
 
@@ -38,7 +38,7 @@ QUnit.test(
     function (assert)
     {
         const prev = mojave.dom.traverse.prev;
-        const element = document.querySelector(".test-element-prev.element1");
+        const element = document.querySelector(".element1");
 
         const result = prev(element);
 
@@ -52,11 +52,11 @@ QUnit.test(
     function (assert)
     {
         const prev = mojave.dom.traverse.prev;
-        const element = document.querySelector(".test-element-prev.element6");
+        const element = document.querySelector(".element6");
 
         const result = prev(element, ".element2");
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element2"), "contains .element2");
+        assert.ok(result.classList.found("element2"), "found .element2");
     }
 );

--- a/tests/cases/dom/traverse/prev.js
+++ b/tests/cases/dom/traverse/prev.js
@@ -5,9 +5,14 @@ QUnit.module(
         {
             document.getElementById("qunit-fixture").innerHTML =
                 '<div class="test-element-prev element1"></div>' +
-                '<div class="test-element-prev element2"></div>' +
+                '<div class="test-element-prev element2">'+
+                    '<div class="test-element-prev element2-1"></div>' +
+                '</div>' +
                 'Some text' +
-                '<div class="test-element-prev element3"></div>';
+                '<div class="test-element-prev element3"></div>' +
+                '<div class="test-element-prev element4"></div>' +
+                '<div class="test-element-prev element5"></div>' +
+                '<div class="test-element-prev element6"></div>';
         }
     }
 );
@@ -18,12 +23,12 @@ QUnit.test(
     function (assert)
     {
         const prev = mojave.dom.traverse.prev;
-        const element = document.querySelector(".test-element-prev.element2");
+        const element = document.querySelector(".test-element-prev.element3");
 
         const result = prev(element);
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element1"), "contains .element1");
+        assert.ok(result.classList.contains("element2"), "contains .element2");
     }
 );
 
@@ -47,11 +52,11 @@ QUnit.test(
     function (assert)
     {
         const prev = mojave.dom.traverse.prev;
-        const element = document.querySelector(".test-element-prev.element3");
+        const element = document.querySelector(".test-element-prev.element6");
 
-        const result = prev(element, ".element1");
+        const result = prev(element, ".element2");
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.contains("element1"), "contains .element1");
+        assert.ok(result.classList.contains("element2"), "contains .element2");
     }
 );

--- a/tests/cases/dom/traverse/prev.js
+++ b/tests/cases/dom/traverse/prev.js
@@ -42,7 +42,7 @@ QUnit.test(
 
         const result = prev(element);
 
-        assert.notOk(result, "found 0 elements");
+        assert.ok(null === result, "found 0 elements");
     }
 );
 

--- a/tests/cases/dom/traverse/prev.js
+++ b/tests/cases/dom/traverse/prev.js
@@ -28,7 +28,7 @@ QUnit.test(
         const result = prev(element);
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.found("element2"), "found .element2");
+        assert.ok(result.classList.contains("element2"), "found .element2");
     }
 );
 
@@ -57,6 +57,6 @@ QUnit.test(
         const result = prev(element, ".element2");
 
         assert.ok(result, "found 1 element");
-        assert.ok(result.classList.found("element2"), "found .element2");
+        assert.ok(result.classList.contains("element2"), "found .element2");
     }
 );

--- a/tests/cases/dom/traverse/prev.js
+++ b/tests/cases/dom/traverse/prev.js
@@ -1,0 +1,57 @@
+QUnit.module(
+    "prev()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element-prev element1"></div>' +
+                '<div class="test-element-prev element2"></div>' +
+                'Some text' +
+                '<div class="test-element-prev element3"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "prev() with an element in the middle, without selector",
+    function (assert)
+    {
+        const prev = mojave.dom.traverse.prev;
+        const element = document.querySelector(".test-element-prev.element2");
+
+        const result = prev(element);
+
+        assert.ok(result, "found 1 element");
+        assert.ok(result.classList.contains("element1"), "contains .element1");
+    }
+);
+
+
+QUnit.test(
+    "prev() with an element at the start, without selector",
+    function (assert)
+    {
+        const prev = mojave.dom.traverse.prev;
+        const element = document.querySelector(".test-element-prev.element1");
+
+        const result = prev(element);
+
+        assert.notOk(result, "found 0 elements");
+    }
+);
+
+
+QUnit.test(
+    "prev() with an element at the end, with selector",
+    function (assert)
+    {
+        const prev = mojave.dom.traverse.prev;
+        const element = document.querySelector(".test-element-prev.element3");
+
+        const result = prev(element, ".element1");
+
+        assert.ok(result, "found 1 element");
+        assert.ok(result.classList.contains("element1"), "contains .element1");
+    }
+);

--- a/tests/cases/dom/traverse/prevAll.js
+++ b/tests/cases/dom/traverse/prevAll.js
@@ -5,10 +5,14 @@ QUnit.module(
         {
             document.getElementById("qunit-fixture").innerHTML =
                 '<div class="test-element-prevAll element1"></div>' +
-                '<div class="test-element-prevAll test-class-prevAll element2"></div>' +
+                '<div class="test-element-prevAll test-class-prevAll element2">' +
+                    '<div class="test-element-prevAll element2-1"></div>' +
+                '</div>' +
                 'Some text' +
                 '<div class="test-element-prevAll test-class-prevAll element3"></div>' +
-                '<div class="test-element-prevAll element4"></div>';
+                '<div class="test-element-prevAll element4"></div>' +
+                '<div class="test-element-prevAll element5"></div>' +
+                '<div class="test-element-prevAll element6"></div>';
         }
     }
 );
@@ -34,14 +38,16 @@ QUnit.test(
     function (assert)
     {
         const prevAll = mojave.dom.traverse.prevAll;
-        const element = document.querySelector(".test-element-prevAll.element4");
+        const element = document.querySelector(".test-element-prevAll.element6");
 
         const result = prevAll(element);
 
-        assert.equal(result.length, 3, "found 3 elements");
-        assert.ok(result[0].classList.contains("element3"), "contains .element3");
-        assert.ok(result[1].classList.contains("element2"), "contains .element2");
-        assert.ok(result[2].classList.contains("element1"), "contains .element1");
+        assert.equal(result.length, 5, "found 5 elements");
+        assert.ok(result[0].classList.contains("element5"), "contains .element5");
+        assert.ok(result[1].classList.contains("element4"), "contains .element4");
+        assert.ok(result[2].classList.contains("element3"), "contains .element3");
+        assert.ok(result[3].classList.contains("element2"), "contains .element2");
+        assert.ok(result[4].classList.contains("element1"), "contains .element1");
     }
 );
 

--- a/tests/cases/dom/traverse/prevAll.js
+++ b/tests/cases/dom/traverse/prevAll.js
@@ -28,7 +28,7 @@ QUnit.test(
         const result = prevAll(element);
 
         assert.equal(result.length, 1, "found 1 element");
-        assert.ok(result[0].classList.found("element1"), "found .element1");
+        assert.ok(result[0].classList.contains("element1"), "found .element1");
     }
 );
 
@@ -43,11 +43,11 @@ QUnit.test(
         const result = prevAll(element);
 
         assert.equal(result.length, 5, "found 5 elements");
-        assert.ok(result[0].classList.found("element5"), "found .element5");
-        assert.ok(result[1].classList.found("element4"), "found .element4");
-        assert.ok(result[2].classList.found("element3"), "found .element3");
-        assert.ok(result[3].classList.found("element2"), "found .element2");
-        assert.ok(result[4].classList.found("element1"), "found .element1");
+        assert.ok(result[0].classList.contains("element5"), "found .element5");
+        assert.ok(result[1].classList.contains("element4"), "found .element4");
+        assert.ok(result[2].classList.contains("element3"), "found .element3");
+        assert.ok(result[3].classList.contains("element2"), "found .element2");
+        assert.ok(result[4].classList.contains("element1"), "found .element1");
     }
 );
 
@@ -77,7 +77,7 @@ QUnit.test(
         const result = prevAll(element, ".test-class");
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.found("element3"), "found .element3");
-        assert.ok(result[1].classList.found("element2"), "found .element2");
+        assert.ok(result[0].classList.contains("element3"), "found .element3");
+        assert.ok(result[1].classList.contains("element2"), "found .element2");
     }
 );

--- a/tests/cases/dom/traverse/prevAll.js
+++ b/tests/cases/dom/traverse/prevAll.js
@@ -4,15 +4,15 @@ QUnit.module(
         beforeEach: function ()
         {
             document.getElementById("qunit-fixture").innerHTML =
-                '<div class="test-element-prevAll element1"></div>' +
-                '<div class="test-element-prevAll test-class-prevAll element2">' +
-                    '<div class="test-element-prevAll element2-1"></div>' +
+                '<div class="test-element element1"></div>' +
+                '<div class="test-element test-class element2">' +
+                    '<div class="test-element element2-1"></div>' +
                 '</div>' +
                 'Some text' +
-                '<div class="test-element-prevAll test-class-prevAll element3"></div>' +
-                '<div class="test-element-prevAll element4"></div>' +
-                '<div class="test-element-prevAll element5"></div>' +
-                '<div class="test-element-prevAll element6"></div>';
+                '<div class="test-element test-class element3"></div>' +
+                '<div class="test-element element4"></div>' +
+                '<div class="test-element element5"></div>' +
+                '<div class="test-element element6"></div>';
         }
     }
 );
@@ -23,12 +23,12 @@ QUnit.test(
     function (assert)
     {
         const prevAll = mojave.dom.traverse.prevAll;
-        const element = document.querySelector(".test-element-prevAll.element2");
+        const element = document.querySelector(".element2");
 
         const result = prevAll(element);
 
         assert.equal(result.length, 1, "found 1 element");
-        assert.ok(result[0].classList.contains("element1"), "contains .element1");
+        assert.ok(result[0].classList.found("element1"), "found .element1");
     }
 );
 
@@ -38,16 +38,16 @@ QUnit.test(
     function (assert)
     {
         const prevAll = mojave.dom.traverse.prevAll;
-        const element = document.querySelector(".test-element-prevAll.element6");
+        const element = document.querySelector(".element6");
 
         const result = prevAll(element);
 
         assert.equal(result.length, 5, "found 5 elements");
-        assert.ok(result[0].classList.contains("element5"), "contains .element5");
-        assert.ok(result[1].classList.contains("element4"), "contains .element4");
-        assert.ok(result[2].classList.contains("element3"), "contains .element3");
-        assert.ok(result[3].classList.contains("element2"), "contains .element2");
-        assert.ok(result[4].classList.contains("element1"), "contains .element1");
+        assert.ok(result[0].classList.found("element5"), "found .element5");
+        assert.ok(result[1].classList.found("element4"), "found .element4");
+        assert.ok(result[2].classList.found("element3"), "found .element3");
+        assert.ok(result[3].classList.found("element2"), "found .element2");
+        assert.ok(result[4].classList.found("element1"), "found .element1");
     }
 );
 
@@ -57,7 +57,7 @@ QUnit.test(
     function (assert)
     {
         const prevAll = mojave.dom.traverse.prevAll;
-        const element = document.querySelector(".test-element-prevAll.element1");
+        const element = document.querySelector(".element1");
 
         const result = prevAll(element);
 
@@ -72,12 +72,12 @@ QUnit.test(
     function (assert)
     {
         const prevAll = mojave.dom.traverse.prevAll;
-        const element = document.querySelector(".test-element-prevAll.element4");
+        const element = document.querySelector(".element4");
 
-        const result = prevAll(element, ".test-class-prevAll");
+        const result = prevAll(element, ".test-class");
 
         assert.equal(result.length, 2, "found 2 elements");
-        assert.ok(result[0].classList.contains("element3"), "contains .element3");
-        assert.ok(result[1].classList.contains("element2"), "contains .element2");
+        assert.ok(result[0].classList.found("element3"), "found .element3");
+        assert.ok(result[1].classList.found("element2"), "found .element2");
     }
 );

--- a/tests/cases/dom/traverse/prevAll.js
+++ b/tests/cases/dom/traverse/prevAll.js
@@ -1,0 +1,77 @@
+QUnit.module(
+    "prevAll()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element-prevAll element1"></div>' +
+                '<div class="test-element-prevAll test-class-prevAll element2"></div>' +
+                'Some text' +
+                '<div class="test-element-prevAll test-class-prevAll element3"></div>' +
+                '<div class="test-element-prevAll element4"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "prevAll() with an element in the middle, without selector",
+    function (assert)
+    {
+        const prevAll = mojave.dom.traverse.prevAll;
+        const element = document.querySelector(".test-element-prevAll.element2");
+
+        const result = prevAll(element);
+
+        assert.equal(result.length, 1, "found 1 element");
+        assert.ok(result[0].classList.contains("element1"), "contains .element1");
+    }
+);
+
+
+QUnit.test(
+    "prevAll() with an element at the end, without selector",
+    function (assert)
+    {
+        const prevAll = mojave.dom.traverse.prevAll;
+        const element = document.querySelector(".test-element-prevAll.element4");
+
+        const result = prevAll(element);
+
+        assert.equal(result.length, 3, "found 3 elements");
+        assert.ok(result[0].classList.contains("element3"), "contains .element3");
+        assert.ok(result[1].classList.contains("element2"), "contains .element2");
+        assert.ok(result[2].classList.contains("element1"), "contains .element1");
+    }
+);
+
+
+QUnit.test(
+    "prevAll() with an element at the start, without selector",
+    function (assert)
+    {
+        const prevAll = mojave.dom.traverse.prevAll;
+        const element = document.querySelector(".test-element-prevAll.element1");
+
+        const result = prevAll(element);
+
+        assert.equal(result.length, 0, "found 0 elements");
+    }
+);
+
+
+
+QUnit.test(
+    "prevAll() with an element at the end, with selector",
+    function (assert)
+    {
+        const prevAll = mojave.dom.traverse.prevAll;
+        const element = document.querySelector(".test-element-prevAll.element4");
+
+        const result = prevAll(element, ".test-class-prevAll");
+
+        assert.equal(result.length, 2, "found 2 elements");
+        assert.ok(result[0].classList.contains("element3"), "contains .element3");
+        assert.ok(result[1].classList.contains("element2"), "contains .element2");
+    }
+);


### PR DESCRIPTION
## Unit tests

`prev()`, `prevAll()`, `next()`,  `nextAll()`

- with an element in the middle, without selector
- with an element at the start, without selector
- with an element at the end, without selector
- with an element at the end, with selector
- with an element at the start, with selector

## All tests pass

![mojave results](https://user-images.githubusercontent.com/984069/27694493-8bee58f0-5cec-11e7-995a-0ab38c1ef093.png)
