### PR TITLE
next() unit test for a non-existent selector

### DIFF
--- a/tests/cases/dom/traverse/next.js
+++ b/tests/cases/dom/traverse/next.js
@@ -60,3 +60,17 @@ QUnit.test(
         assert.ok(result.classList.contains("element3"), "found .element3");
     }
 );
+
+
+QUnit.test(
+    "next() with a selector where nothing matches",
+    function (assert)
+    {
+        const next = mojave.dom.traverse.next;
+        const element = document.querySelector(".element1");
+
+        const result = next(element, ".missing");
+
+        assert.ok(null === result, "found 0 elements");
+    }
+);


### PR DESCRIPTION
## Unit test

`next()`

## test passes

![mojave results](https://user-images.githubusercontent.com/984069/27832561-62b171ca-60cf-11e7-8ced-38b0270f5cc5.png)

