### PR TITLE
add remove() unit tests

### DIFF
--- a/tests/cases/dom/manipulate/remove.js
+++ b/tests/cases/dom/manipulate/remove.js
@@ -47,27 +47,3 @@ QUnit.test(
         assert.equal(result.length, 0, ".missing not found");
     }
 );
-
-
-QUnit.test(
-    "remove() on non-existent element (workaround)",
-    function (assert)
-    {
-        const find = mojave.dom.traverse.find;
-        const element = document.querySelector(".missing");
-        const removing = mojave.dom.manipulate.remove;
-
-        let removed;
-        if (element !== null) {
-            removing(element);
-            removed = true;
-        } else {
-            removed = false;
-        }
-
-        const result = find(".missing");
-
-        assert.ok(false === removed, "couldn't remove element, element doesn't exist");
-        assert.equal(result.length, 0, ".missing not found");
-    }
-);

--- a/tests/cases/dom/manipulate/remove.js
+++ b/tests/cases/dom/manipulate/remove.js
@@ -1,0 +1,73 @@
+QUnit.module(
+    "remove()",
+    {
+        beforeEach: function ()
+        {
+            document.getElementById("qunit-fixture").innerHTML =
+                '<div class="test-element element1"></div>' +
+                '<div class="test-element element2">'+
+                '<div class="test-element element2-1"></div>' +
+                '</div>' +
+                'Some text' +
+                '<div class="test-element element3"></div>';
+        }
+    }
+);
+
+
+QUnit.test(
+    "remove() on existent element",
+    function (assert)
+    {
+        const find = mojave.dom.traverse.find;
+        const element = document.querySelector(".element2");
+        const removing = mojave.dom.manipulate.remove;
+
+        removing(element);
+
+        const result = find(".element2");
+
+        assert.equal(result.length, 0, ".element2 successfully removed");
+    }
+);
+
+
+QUnit.test(
+    "remove() on non-existent element (fails)",
+    function (assert)
+    {
+        const find = mojave.dom.traverse.find;
+        const element = document.querySelector(".missing");
+        const removing = mojave.dom.manipulate.remove;
+
+        removing(element);
+
+        const result = find(".missing");
+
+        assert.equal(result.length, 0, ".missing not found");
+    }
+);
+
+
+QUnit.test(
+    "remove() on non-existent element (workaround)",
+    function (assert)
+    {
+        const find = mojave.dom.traverse.find;
+        const element = document.querySelector(".missing");
+        const removing = mojave.dom.manipulate.remove;
+
+        let removed;
+        if (element !== null) {
+            removing(element);
+            removed = true;
+        } else {
+            removed = false;
+        }
+
+        const result = find(".missing");
+
+        assert.ok(false === removed, "couldn't remove element, element doesn't exist");
+        assert.equal(result.length, 0, ".missing not found");
+    }
+);


### PR DESCRIPTION
## Unit tests

- `remove()` on existent element
- `remove()` on non-existent element

## Expected result (test 2)
`remove(".missing")` should check if the requested element exists and if it doesn't, return a message saying so

## Current result (test 2)
`remove(".missing")` doesn't check if the requested element exists and returns an error:
```
TypeError: Cannot read property 'parentNode' of null
```
![mojave results](https://user-images.githubusercontent.com/984069/27855686-b3c5e248-616b-11e7-8358-965f9b111d00.png)

## About the tests
There are 2 unit tests for the non-existent element. This is because `remove()` doesn’t check if an element exists and then fails shortly after trying to get that element’s parentNode.
The second unit test has that check added manually.

## Additional
I’m not entirely sure how to check if this function did what it did. So I just used `find()` to see if we can find it. I feel like we should add another check before the removal function to see if it existed in the first place.

As of right now, that’s not really an issue; as previously mentioned `remove()` fails when the element doesn’t exist. Once that is fixed and it stops failing it would probably make sense to add an additional check. Or ask for a return directly in the function.

Signed-off-by: Patrick Kontschak <pk@becklyn.com>