### PR TITLE
add append() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -2,6 +2,7 @@ import "../cases/date/compare";
 import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
+import "../cases/dom/manipulate/append";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";

--- a/tests/cases/dom/manipulate/append.js
+++ b/tests/cases/dom/manipulate/append.js
@@ -1,0 +1,88 @@
+import QUnit from "qunitjs";
+import {append} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/append()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = `
+                <div id="test-parent">
+                    <div class="first"></div>
+                    <div class="second"></div>
+                </div>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and child",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const appendingChild = document.createElement("div");
+        const className = "identifier";
+        appendingChild.classList.add(className);
+        append(parent, appendingChild);
+
+        assert.equal(document.getElementsByClassName(className).length, 1, "has one occurrence");
+        assert.equal(parent.lastElementChild, appendingChild, "is last element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and html string as a child",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const className = "identifier";
+        append(parent, `<div class="${className}"></div>`);
+
+        assert.ok(parent.lastElementChild.classList.contains(className), "is last element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and an array of nodes as children",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const appendingChild = document.createElement("div");
+        const secondAppendingChild = document.createElement("div");
+        append(parent, [appendingChild, secondAppendingChild]);
+
+        assert.equal(parent.children[parent.children.length - 2], appendingChild, "is second to last element");
+        assert.equal(parent.lastElementChild, secondAppendingChild, "is last element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and an invalid child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                append(document.getElementById("test-parent"), null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with invalid parent and a node as a child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                append(null, document.createElement("div"));
+            },
+            "function threw an error"
+        );
+    }
+);


### PR DESCRIPTION
## Unit tests

The following tests are being created by this pull request:

append() with node as parent and child
append() with node as parent and html string as a child
append() with node as parent and an array of nodes as children
append() with node as parent and an invalid child
append() with invalid parent and a node as a child


## Expected result

- It is expected that the append()-function places a child/many children not only inside but also at the end of the parent element.

- The append()-function should check if the parent element exists and if it doesn't, throw an error saying so.

- The append()-function should also check if the child, which will be appended, is valid and throw an error if this is not the case.

## Current result

All tests run successfully.