### PR TITLE
add prepend() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -3,6 +3,7 @@ import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";
+import "../cases/dom/manipulate/prepend";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";

--- a/tests/cases/dom/manipulate/prepend.js
+++ b/tests/cases/dom/manipulate/prepend.js
@@ -52,7 +52,7 @@ QUnit.test(
         const secondPrependingChild = document.createElement("div");
         prepend(parent, [prependingChild, secondPrependingChild]);
 
-        assert.equal(parent.firstElementChild, prependingChild, "is first element");
+        assert.equal(parent.children[0], prependingChild, "is first element");
         assert.equal(parent.children[1], secondPrependingChild, "is second element");
     }
 );

--- a/tests/cases/dom/manipulate/prepend.js
+++ b/tests/cases/dom/manipulate/prepend.js
@@ -1,0 +1,88 @@
+import QUnit from "qunitjs";
+import {prepend} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/prepend()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = `
+                <div id="test-parent">
+                    <div class="first"></div>
+                    <div class="second"></div>
+                </div>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and child",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const prependingChild = document.createElement("div");
+        const className = "identifier";
+        prependingChild.classList.add(className);
+        prepend(parent, prependingChild);
+
+        assert.equal(document.getElementsByClassName(className).length, 1, "has one occurrence");
+        assert.equal(parent.firstElementChild, prependingChild, "is first element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and html string as a child",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const className = "identifier";
+        prepend(parent, `<div class="${className}"></div>`);
+
+        assert.ok(parent.firstElementChild.classList.contains(className), "is first element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and an array of nodes as children",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const prependingChild = document.createElement("div");
+        const secondPrependingChild = document.createElement("div");
+        prepend(parent, [prependingChild, secondPrependingChild]);
+
+        assert.equal(parent.firstElementChild, prependingChild, "is first element");
+        assert.equal(parent.children[1], secondPrependingChild, "is second element");
+    }
+);
+
+
+QUnit.test(
+    "with node as parent and invalid child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                prepend(document.getElementById("test-parent"), null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with invalid parent and a node as a child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                prepend(null, document.createElement("div"));
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/manipulate/prepend.js
+++ b/tests/cases/dom/manipulate/prepend.js
@@ -22,11 +22,10 @@ QUnit.test(
     {
         const parent = document.getElementById("test-parent");
         const prependingChild = document.createElement("div");
-        const className = "identifier";
-        prependingChild.classList.add(className);
+        prependingChild.classList.add("className");
         prepend(parent, prependingChild);
 
-        assert.equal(document.getElementsByClassName(className).length, 1, "has one occurrence");
+        assert.equal(document.getElementsByClassName("className").length, 1, "has one occurrence");
         assert.equal(parent.firstElementChild, prependingChild, "is first element");
     }
 );
@@ -37,10 +36,9 @@ QUnit.test(
     (assert) =>
     {
         const parent = document.getElementById("test-parent");
-        const className = "identifier";
-        prepend(parent, `<div class="${className}"></div>`);
+        prepend(parent, `<div class="className"></div>`);
 
-        assert.ok(parent.firstElementChild.classList.contains(className), "is first element");
+        assert.ok(parent.firstElementChild.classList.contains("className"), "is first element");
     }
 );
 

--- a/tests/cases/dom/manipulate/prepend.js
+++ b/tests/cases/dom/manipulate/prepend.js
@@ -1,11 +1,12 @@
+import {children, find, findOne} from "../../../../dom/traverse";
+import {createElement, prepend} from "../../../../dom/manipulate";
 import QUnit from "qunitjs";
-import {prepend} from "../../../../dom/manipulate";
 
 QUnit.module("dom/manipulate/prepend()",
     {
         beforeEach: () =>
         {
-            document.getElementById("qunit-fixture").innerHTML = `
+            findOne("#qunit-fixture").innerHTML = `
                 <div id="test-parent">
                     <div class="first"></div>
                     <div class="second"></div>
@@ -20,12 +21,11 @@ QUnit.test(
     "with node as parent and child",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const prependingChild = document.createElement("div");
-        prependingChild.classList.add("className");
+        const parent = findOne("#test-parent");
+        const prependingChild = createElement(`<div class="className"></div>`);
         prepend(parent, prependingChild);
 
-        assert.equal(document.getElementsByClassName("className").length, 1, "has one occurrence");
+        assert.equal(find(".className").length, 1, "has one occurrence");
         assert.equal(parent.firstElementChild, prependingChild, "is first element");
     }
 );
@@ -35,7 +35,7 @@ QUnit.test(
     "with node as parent and html string as a child",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
+        const parent = findOne("#test-parent");
         prepend(parent, `<div class="className"></div>`);
 
         assert.ok(parent.firstElementChild.classList.contains("className"), "is first element");
@@ -47,13 +47,13 @@ QUnit.test(
     "with node as parent and an array of nodes as children",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const prependingChild = document.createElement("div");
-        const secondPrependingChild = document.createElement("div");
+        const parent = findOne("#test-parent");
+        const prependingChildren = [createElement("div"), createElement("div")]
         prepend(parent, [prependingChild, secondPrependingChild]);
 
-        assert.equal(parent.children[0], prependingChild, "is first element");
-        assert.equal(parent.children[1], secondPrependingChild, "is second element");
+        const childElements = children(parent);
+        assert.equal(childElements[0], prependingChildren[0], "is first element");
+        assert.equal(childElements[1], prependingChildren[1], "is second element");
     }
 );
 
@@ -64,7 +64,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                prepend(document.getElementById("test-parent"), null);
+                prepend(findOne("#test-parent"), null);
             },
             "function threw an error"
         );
@@ -78,7 +78,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                prepend(null, document.createElement("div"));
+                prepend(null, createElement("div"));
             },
             "function threw an error"
         );


### PR DESCRIPTION
## Unit tests

The following tests are being created by this pull request:

prepend() with node as parent and child
prepend() with node as parent and html string as a child
prepend() with node as parent and an array of nodes as children
prepend() with node as parent and an invalid child
prepend() with invalid parent and a node as a child


## Expected result

- It is expected that the prepend()-function places a child/many children not only inside but also at the very start in the list of the parent element.

- The prepend()-function should check if the parent element exists and if it doesn't, throw an error saying so.

- The prepend()-function should also check if the child, which will be prepended, is valid and throw an error if this is not the case.

## Current result

All tests run successfully.
