### PR TITLE
add after() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -2,6 +2,7 @@ import "../cases/date/compare";
 import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
+import "../cases/dom/manipulate/after";
 import "../cases/dom/manipulate/append";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";

--- a/tests/cases/dom/manipulate/after.js
+++ b/tests/cases/dom/manipulate/after.js
@@ -1,0 +1,100 @@
+import {after, createElement} from "../../../../dom/manipulate";
+import {find, findOne} from "../../../../dom/traverse";
+import QUnit from "qunitjs";
+
+QUnit.module("dom/manipulate/after()",
+    {
+        beforeEach: () =>
+        {
+            findOne("#qunit-fixture").innerHTML = `
+                <div id="test-parent">
+                    <div class="first"></div>
+                    <div class="second"></div>
+                </div>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and insert",
+    (assert) =>
+    {
+        const children = findOne("#test-parent").children;
+        const insert = createElement("div");
+        const afterReference = children[0];
+        after(afterReference, insert);
+
+        assert.equal(children[0], afterReference, "element after the reference element still exists and is positioned right before the insert");
+        assert.equal(children[1], insert, "reference element still exists and is positioned right after the insert");
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and html string as a child",
+    (assert) =>
+    {
+        const children = findOne("#test-parent").children;
+        const afterReference = children[0];
+        after(afterReference, `<div class="test"></div>`);
+
+        assert.equal(children[0], afterReference, "element after the reference element still exists and is positioned right after the insert");
+        assert.ok(children[1].classList.contains("test"), "is before the reference element");
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and an array of nodes as children",
+    (assert) =>
+    {
+        const children = findOne("#test-parent").children;
+        const afterReference = children[0];
+        const insertArray = [createElement("div"), createElement("div")];
+        after(afterReference, insertArray);
+
+        assert.equal(children[0], afterReference, "reference element still exists and is positioned right before the inserts");
+        assert.equal(children[1], insertArray[0], "first insert is at the spot after the reference element");
+        assert.equal(children[2], insertArray[1], "second insert is after the first insert");
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and an invalid child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                after(find(".first")[0], null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with invalid reference and a node as a child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                after(null, document.createElement("div"));
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and an empty child as insert",
+    (assert) =>
+    {
+        after(find(".first")[0], "null");
+        assert.ok(true, "the previous code should have run successfully");
+    }
+);


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

after() with node as reference and insert
after() with node as reference and html string as a insert
after() with node as reference and an array of nodes as inserts
after() with node as reference and an invalid insert
after() with invalid reference and a node as a insert


## Expected result

- It is expected that the after()-function places an insert/many inserts after the reference element.

- The after()-function should check if the reference element exists and if it doesn't, throw an error saying so.

- The after()-function should also check if the child, which will be placed after the reference, is valid and throw an error if this is not the case.

## Current result

All tests run successfully.
