### PR TITLE
add before() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -3,6 +3,7 @@ import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";
+import "../cases/dom/manipulate/before";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";

--- a/tests/cases/dom/manipulate/before.js
+++ b/tests/cases/dom/manipulate/before.js
@@ -1,5 +1,6 @@
 import QUnit from "qunitjs";
 import {before} from "../../../../dom/manipulate";
+import {find} from "../../../../dom/traverse";
 
 QUnit.module("dom/manipulate/before()",
     {
@@ -20,16 +21,13 @@ QUnit.test(
     "with node as reference and insert",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
+        const children = document.getElementById("test-parent").children;
         const insert = document.createElement("div");
-        const reference = document.getElementsByClassName("second")[0];
+        const reference = children[1];
         before(reference, insert);
 
-        assert.equal(
-            Array.prototype.indexOf.call(parent.children, insert),
-            Array.prototype.indexOf.call(parent.children, reference) - 1,
-            "is before the reference element"
-        );
+        assert.equal(children[1], insert, "is at the spot of the reference element");
+        assert.equal(children[2], reference, "reference element still exists and is positioned right after the insert");
     }
 );
 
@@ -38,15 +36,10 @@ QUnit.test(
     "with node as reference and html string as an insert",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const reference = document.getElementsByClassName("second")[0];
-        const className = "identifierForMyTest";
-        before(reference, `<div class="${className}"></div>`);
+        const children = document.getElementById("test-parent").children;
+        before(children[1], `<div class="test"></div>`);
 
-        assert.ok(
-            parent.children[Array.prototype.indexOf.call(parent.children, reference) - 1].classList.contains(className),
-            "is before the reference element"
-        );
+        assert.ok(children[1].classList.contains("test"), "is before the reference element");
     }
 );
 
@@ -55,21 +48,14 @@ QUnit.test(
     "with node as reference and an array of nodes as inserts",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const reference = document.getElementsByClassName("second")[0];
+        const children = document.getElementById("test-parent").children;
+        const reference = children[1];
         const insertArray = [document.createElement("div"), document.createElement("div")];
         before(reference, insertArray);
 
-        assert.equal(
-            Array.prototype.indexOf.call(parent.children, insertArray[0]),
-            Array.prototype.indexOf.call(parent.children, reference) - insertArray.length,
-            "first element of array is before the reference element"
-        );
-        assert.equal(
-            Array.prototype.indexOf.call(parent.children, insertArray[1]),
-            Array.prototype.indexOf.call(parent.children, reference) - (insertArray.length - 1),
-            "second element of array is after first element of array and is before the reference element"
-        );
+        assert.equal(children[1], insertArray[0], "first insert is at the spot of the reference element");
+        assert.equal(children[2], insertArray[1], "second insert is after the first insert");
+        assert.equal(children[3], reference, "reference element still exists and is positioned right after the inserts");
     }
 );
 
@@ -80,7 +66,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                before(document.getElementsByClassName("second")[0], null);
+                before(document.getElementById("test-parent").children[0], null);
             },
             "function threw an error"
         );

--- a/tests/cases/dom/manipulate/before.js
+++ b/tests/cases/dom/manipulate/before.js
@@ -1,0 +1,116 @@
+import QUnit from "qunitjs";
+import {before} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/before()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = `
+                <div id="test-parent">
+                    <div class="first"></div>
+                    <div class="second"></div>
+                </div>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and insert",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const insert = document.createElement("div");
+        const reference = document.getElementsByClassName("second")[0];
+        before(reference, insert);
+
+        assert.equal(
+            Array.prototype.indexOf.call(parent.children, insert),
+            Array.prototype.indexOf.call(parent.children, reference) - 1,
+            "is before the reference element"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and html string as a child",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const reference = document.getElementsByClassName("second")[0];
+        const className = "identifierForMyTest";
+        before(reference, `<div class="${className}"></div>`);
+
+        assert.ok(
+            parent.children[Array.prototype.indexOf.call(parent.children, reference) - 1].classList.contains(className),
+            "is before the reference element"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and an array of nodes as children",
+    (assert) =>
+    {
+        const parent = document.getElementById("test-parent");
+        const reference = document.getElementsByClassName("second")[0];
+        const insertArray = [document.createElement("div"), document.createElement("div")];
+        before(reference, insertArray);
+
+        assert.equal(
+            Array.prototype.indexOf.call(parent.children, insertArray[0]),
+            Array.prototype.indexOf.call(parent.children, reference) - insertArray.length,
+            "first element of array is before the reference element"
+        );
+        assert.equal(
+            Array.prototype.indexOf.call(parent.children, insertArray[1]),
+            Array.prototype.indexOf.call(parent.children, reference) - (insertArray.length - 1),
+            "second element of array is after first element of array and is before the reference element"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and an invalid child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                before(document.getElementsByClassName("second")[0], null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with invalid reference and a node as a child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                before(null, document.createElement("div"));
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with node as reference and empty string as a child",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                before(document.getElementById("testParentElement"), "");
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/manipulate/before.js
+++ b/tests/cases/dom/manipulate/before.js
@@ -35,7 +35,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "with node as reference and html string as a child",
+    "with node as reference and html string as an insert",
     (assert) =>
     {
         const parent = document.getElementById("test-parent");
@@ -52,7 +52,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "with node as reference and an array of nodes as children",
+    "with node as reference and an array of nodes as inserts",
     (assert) =>
     {
         const parent = document.getElementById("test-parent");
@@ -75,7 +75,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "with node as reference and an invalid child",
+    "with node as reference and an invalid insert",
     (assert) =>
     {
         assert.throws(
@@ -89,7 +89,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "with invalid reference and a node as a child",
+    "with invalid reference and a node as an insert",
     (assert) =>
     {
         assert.throws(
@@ -103,7 +103,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "with node as reference and empty string as a child",
+    "with node as reference and empty string as an insert",
     (assert) =>
     {
         assert.throws(

--- a/tests/cases/dom/manipulate/before.js
+++ b/tests/cases/dom/manipulate/before.js
@@ -1,12 +1,12 @@
+import {before, createElement} from "../../../../dom/manipulate";
+import {find, findOne} from "../../../../dom/traverse";
 import QUnit from "qunitjs";
-import {before} from "../../../../dom/manipulate";
-import {find} from "../../../../dom/traverse";
 
 QUnit.module("dom/manipulate/before()",
     {
         beforeEach: () =>
         {
-            document.getElementById("qunit-fixture").innerHTML = `
+            findOne("#qunit-fixture").innerHTML = `
                 <div id="test-parent">
                     <div class="first"></div>
                     <div class="second"></div>
@@ -21,8 +21,8 @@ QUnit.test(
     "with node as reference and insert",
     (assert) =>
     {
-        const children = document.getElementById("test-parent").children;
-        const insert = document.createElement("div");
+        const children = findOne("#test-parent").children;
+        const insert = createElement("div");
         const reference = children[1];
         before(reference, insert);
 
@@ -36,7 +36,7 @@ QUnit.test(
     "with node as reference and html string as an insert",
     (assert) =>
     {
-        const children = document.getElementById("test-parent").children;
+        const children = findOne("#test-parent").children;
         before(children[1], `<div class="test"></div>`);
 
         assert.ok(children[1].classList.contains("test"), "is before the reference element");
@@ -48,7 +48,7 @@ QUnit.test(
     "with node as reference and an array of nodes as inserts",
     (assert) =>
     {
-        const children = document.getElementById("test-parent").children;
+        const children = findOne("#test-parent").children;
         const reference = children[1];
         const insertArray = [document.createElement("div"), document.createElement("div")];
         before(reference, insertArray);
@@ -66,7 +66,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                before(document.getElementById("test-parent").children[0], null);
+                before(findOne("test-parent").children[0], null);
             },
             "function threw an error"
         );

--- a/tests/cases/dom/manipulate/before.js
+++ b/tests/cases/dom/manipulate/before.js
@@ -92,11 +92,7 @@ QUnit.test(
     "with node as reference and empty string as an insert",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                before(document.getElementById("testParentElement"), "");
-            },
-            "function threw an error"
-        );
+        before(find(".second")[0], "");
+        assert.ok(true, "the previous code should have run successfully");
     }
 );


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

before() with node as reference and insert
before() with node as reference and html string as a insert
before() with node as reference and an array of nodes as inserts
before() with node as reference and an invalid insert
before() with invalid reference and a node as a insert


## Expected result

- It is expected that the before()-function places an insert/many inserts before the reference element.

- The before()-function should check if the reference element exists and if it doesn't, throw an error saying so.

- The before()-function should also check if the child, which will be placed before the reference, is valid and throw an error if this is not the case.

## Current result

All tests run successfully.
