### PR TITLE
add createElement() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -3,6 +3,7 @@ import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";
+import "../cases/dom/manipulate/createElement";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";

--- a/tests/cases/dom/manipulate/createElement.js
+++ b/tests/cases/dom/manipulate/createElement.js
@@ -1,0 +1,157 @@
+import QUnit from "qunitjs";
+import {createElement} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/createElement()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = "";
+        },
+    }
+);
+
+
+QUnit.test(
+    "with one parameter",
+    (assert) =>
+    {
+        const tagName = "div";
+        const className = "identifier";
+        const element = createElement(tagName);
+        element.classList.add(className);
+        document.getElementById("qunit-fixture").appendChild(element);
+
+        const result = document.getElementsByClassName(className);
+        assert.equal(result.length, 1, "element was only created once");
+        assert.equal(result[0], element, `created <${tagName}>`);
+    }
+);
+
+
+QUnit.test(
+    "with one parameter (parameter is custom tag)",
+    (assert) =>
+    {
+        const tagName = "customtagname";
+        const className = "identifier";
+        const element = createElement(tagName);
+        element.classList.add(className);
+        document.getElementById("qunit-fixture").appendChild(element);
+
+        assert.equal(document.getElementsByClassName(className)[0], element, `created <${tagName}>`);
+    }
+);
+
+
+QUnit.test(
+    "with one parameter (first parameter is null)",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = createElement(null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with one parameter (first parameter is an empty string)",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = createElement("");
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with two parameters",
+    (assert) =>
+    {
+        const tagName = "div";
+        const className = "identifier";
+        const width = 100;
+        const cssAttributeName = "display";
+        const cssAttributeValue = "none";
+        const element = createElement(tagName,
+            {
+                class: className,
+                width: width,
+                css: {
+                    [cssAttributeName]: cssAttributeValue,
+                },
+            }
+        );
+        document.getElementById("qunit-fixture").appendChild(element);
+
+        const result = document.getElementsByClassName(className)[0];
+        assert.equal(result, element, `created <${tagName}> with the expected class`);
+        assert.equal(result.getAttribute("width"), width, "width attribute has the expected value");
+        assert.equal(result.getAttribute("style"), `${cssAttributeName}: ${cssAttributeValue};`, "style attribute has the expected value");
+    }
+);
+
+
+QUnit.test(
+    "with two parameters (second parameter contains html)",
+    (assert) =>
+    {
+        const tagName = "div";
+        const className = "identifier";
+        const innerHtml = "<div></div>";
+        const element = createElement(tagName,
+            {
+                class: className,
+                html: innerHtml,
+            }
+        );
+        document.getElementById("qunit-fixture").appendChild(element);
+
+        assert.equal(document.getElementsByClassName(className)[0].innerHTML, innerHtml, "innerHTML was added");
+    }
+);
+
+
+QUnit.test(
+    "with two parameters (second parameter contains text and html)",
+    (assert) =>
+    {
+        const tagName = "div";
+        const className = "identifier";
+        const text = "test text";
+        const innerHtml = "<div></div>";
+        const element = createElement(tagName,
+            {
+                class: className,
+                html: innerHtml,
+                text: text,
+            }
+        );
+        document.getElementById("qunit-fixture").appendChild(element);
+
+        const result = document.getElementsByClassName(className)[0];
+        assert.equal(result.textContent, text, "text was added");
+        assert.equal(result.innerHTML.indexOf(innerHtml.substr(0, (innerHtml.indexOf(">") + 1))), -1, "innerHTML was ignored");
+    }
+);
+
+
+QUnit.test(
+    "with two parameters (second parameter is null)",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = createElement("div", null);
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/manipulate/createElement.js
+++ b/tests/cases/dom/manipulate/createElement.js
@@ -1,14 +1,7 @@
 import QUnit from "qunitjs";
 import {createElement} from "../../../../dom/manipulate";
 
-QUnit.module("dom/manipulate/createElement()",
-    {
-        beforeEach: () =>
-        {
-            document.getElementById("qunit-fixture").innerHTML = "";
-        },
-    }
-);
+QUnit.module("dom/manipulate/createElement()");
 
 
 QUnit.test(

--- a/tests/cases/dom/manipulate/createElement.js
+++ b/tests/cases/dom/manipulate/createElement.js
@@ -8,15 +8,10 @@ QUnit.test(
     "with one parameter",
     (assert) =>
     {
-        const tagName = "div";
-        const className = "identifier";
-        const element = createElement(tagName);
-        element.classList.add(className);
-        document.getElementById("qunit-fixture").appendChild(element);
+        const element = createElement("div");
 
-        const result = document.getElementsByClassName(className);
-        assert.equal(result.length, 1, "element was only created once");
-        assert.equal(result[0], element, `created <${tagName}>`);
+        assert.equal(element.tagName.toLowerCase(), "div", "created element with <div> tag");
+        assert.ok(element instanceof HTMLElement, "is HTMLElement");
     }
 );
 
@@ -25,13 +20,10 @@ QUnit.test(
     "with one parameter (parameter is custom tag)",
     (assert) =>
     {
-        const tagName = "customtagname";
-        const className = "identifier";
-        const element = createElement(tagName);
-        element.classList.add(className);
-        document.getElementById("qunit-fixture").appendChild(element);
+        const element = createElement("customtagname");
 
-        assert.equal(document.getElementsByClassName(className)[0], element, `created <${tagName}>`);
+        assert.equal(element.tagName.toLowerCase(), "customtagname", "created with custom tag");
+        assert.ok(element instanceof HTMLElement, "is HTMLElement");
     }
 );
 
@@ -68,26 +60,19 @@ QUnit.test(
     "with two parameters",
     (assert) =>
     {
-        const tagName = "div";
-        const className = "identifier";
-        const width = 100;
-        const cssAttributeName = "display";
-        const cssAttributeValue = "none";
-        const element = createElement(tagName,
+        const element = createElement("div",
             {
-                class: className,
-                width: width,
+                class: "className",
+                width: 100,
                 css: {
-                    [cssAttributeName]: cssAttributeValue,
+                    "display": "none",
                 },
             }
         );
-        document.getElementById("qunit-fixture").appendChild(element);
 
-        const result = document.getElementsByClassName(className)[0];
-        assert.equal(result, element, `created <${tagName}> with the expected class`);
-        assert.equal(result.getAttribute("width"), width, "width attribute has the expected value");
-        assert.equal(result.getAttribute("style"), `${cssAttributeName}: ${cssAttributeValue};`, "style attribute has the expected value");
+        assert.ok(element, "created <div> with the expected class");
+        assert.equal(element.getAttribute("width"), 100, "width attribute has the expected value");
+        assert.equal(element.getAttribute("style"), "display: none;", "style attribute has the expected value");
     }
 );
 
@@ -96,18 +81,14 @@ QUnit.test(
     "with two parameters (second parameter contains html)",
     (assert) =>
     {
-        const tagName = "div";
-        const className = "identifier";
-        const innerHtml = "<div></div>";
-        const element = createElement(tagName,
+        const element = createElement("div",
             {
-                class: className,
-                html: innerHtml,
+                class: "className",
+                html: "<div></div>",
             }
         );
-        document.getElementById("qunit-fixture").appendChild(element);
 
-        assert.equal(document.getElementsByClassName(className)[0].innerHTML, innerHtml, "innerHTML was added");
+        assert.equal(element.innerHTML, "<div></div>", "innerHTML was added");
     }
 );
 
@@ -116,22 +97,16 @@ QUnit.test(
     "with two parameters (second parameter contains text and html)",
     (assert) =>
     {
-        const tagName = "div";
-        const className = "identifier";
-        const text = "test text";
-        const innerHtml = "<div></div>";
-        const element = createElement(tagName,
+        const element = createElement("div",
             {
-                class: className,
-                html: innerHtml,
-                text: text,
+                class: "className",
+                html: "<div></div>",
+                text: "test text",
             }
         );
-        document.getElementById("qunit-fixture").appendChild(element);
 
-        const result = document.getElementsByClassName(className)[0];
-        assert.equal(result.textContent, text, "text was added");
-        assert.equal(result.innerHTML.indexOf(innerHtml.substr(0, (innerHtml.indexOf(">") + 1))), -1, "innerHTML was ignored");
+        assert.equal(element.textContent, "test text", "text was added");
+        assert.equal(element.innerHTML.indexOf("<div>"), -1, "innerHTML was ignored");
     }
 );
 

--- a/tests/cases/dom/manipulate/createElement.js
+++ b/tests/cases/dom/manipulate/createElement.js
@@ -65,14 +65,14 @@ QUnit.test(
                 class: "className",
                 width: 100,
                 css: {
-                    "display": "none",
+                    display: "none",
                 },
             }
         );
 
         assert.ok(element, "created <div> with the expected class");
         assert.equal(element.getAttribute("width"), 100, "width attribute has the expected value");
-        assert.equal(element.getAttribute("style"), "display: none;", "style attribute has the expected value");
+        assert.equal(element.style.display, "none", "style attribute has the expected value");
     }
 );
 


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

createElement() with one parameter
createElement() with one parameter (parameter is custom tag)
createElement() with one parameter (first parameter is null)
createElement() with one parameter (first parameter is an empty string)
createElement() with two parameters
createElement() with two parameters (second parameter contains html)
createElement() with two parameters (second parameter contains text and html)
createElement() with two parameters (second parameter is null)


## Expected result

- It is expected that the createElement()-function simply creates an element with the given attributes.

- The createElement()-function should also check if the parameters, which will be used as attributes, are valid and throw an error if this is not the case.

## Current result

All tests run successfully.
