### PR TITLE
add empty() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -3,6 +3,7 @@ import "../cases/date/format";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";
+import "../cases/dom/manipulate/empty";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";

--- a/tests/cases/dom/manipulate/empty.js
+++ b/tests/cases/dom/manipulate/empty.js
@@ -1,0 +1,65 @@
+import QUnit from "qunitjs";
+import {empty} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/empty()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = `
+                <p id="test-element" class="test">content</p>
+                <p id="test-element-two" class="test">content</p>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with valid node element",
+    (assert) =>
+    {
+        const element = document.getElementById("test-element");
+        empty(element);
+
+        const result = document.getElementById("test-element");
+        assert.equal(result.innerHTML, "", "element is empty");
+    }
+);
+
+
+QUnit.test(
+    "with an array of elements",
+    (assert) =>
+    {
+        const elements = document.getElementsByClassName("test");
+        empty([elements[0], elements[1]]);
+
+        const results = document.getElementsByClassName("test");
+        assert.equal(results[0].innerHTML,"", "first element is empty");
+        assert.equal(results[1].innerHTML,"", "second element is empty");
+    }
+);
+
+
+QUnit.test(
+    "with an (query) string as an element",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                empty("#test-element");
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with an empty array",
+    (assert) =>
+    {
+        empty([]);
+        assert.ok(true, "the previous code should have run successfully");
+    }
+);

--- a/tests/cases/dom/manipulate/empty.js
+++ b/tests/cases/dom/manipulate/empty.js
@@ -7,7 +7,9 @@ QUnit.module("dom/manipulate/empty()",
         beforeEach: () =>
         {
             document.getElementById("qunit-fixture").innerHTML = `
-                <p class="test">content</p>
+                <div class="test">
+                    <p>content</p>
+                </div>
                 <p class="test">content</p>
             `;
         },
@@ -24,6 +26,7 @@ QUnit.test(
         assert.notEqual(element.innerHTML.length, 0, "element contains something before the empty() was executed");
         empty(element);
         assert.equal(element.innerHTML, "", "element is empty");
+        assert.equal(element.children.length, 0, "element contains no children");
     }
 );
 

--- a/tests/cases/dom/manipulate/empty.js
+++ b/tests/cases/dom/manipulate/empty.js
@@ -1,12 +1,12 @@
+import {find, findOne} from "../../../../dom/traverse";
 import QUnit from "qunitjs";
 import {empty} from "../../../../dom/manipulate";
-import {find} from "../../../../dom/traverse";
 
 QUnit.module("dom/manipulate/empty()",
     {
         beforeEach: () =>
         {
-            document.getElementById("qunit-fixture").innerHTML = `
+            findOne("#qunit-fixture").innerHTML = `
                 <div class="test">
                     <p>content</p>
                 </div>

--- a/tests/cases/dom/manipulate/empty.js
+++ b/tests/cases/dom/manipulate/empty.js
@@ -1,13 +1,14 @@
 import QUnit from "qunitjs";
 import {empty} from "../../../../dom/manipulate";
+import {find} from "../../../../dom/traverse";
 
 QUnit.module("dom/manipulate/empty()",
     {
         beforeEach: () =>
         {
             document.getElementById("qunit-fixture").innerHTML = `
-                <p id="test-element" class="test">content</p>
-                <p id="test-element-two" class="test">content</p>
+                <p class="test">content</p>
+                <p class="test">content</p>
             `;
         },
     }
@@ -18,11 +19,11 @@ QUnit.test(
     "with valid node element",
     (assert) =>
     {
-        const element = document.getElementById("test-element");
-        empty(element);
+        const element = find(".test")[0];
 
-        const result = document.getElementById("test-element");
-        assert.equal(result.innerHTML, "", "element is empty");
+        assert.notEqual(element.innerHTML.length, 0, "element contains something before the empty() was executed");
+        empty(element);
+        assert.equal(element.innerHTML, "", "element is empty");
     }
 );
 
@@ -31,12 +32,13 @@ QUnit.test(
     "with an array of elements",
     (assert) =>
     {
-        const elements = document.getElementsByClassName("test");
-        empty([elements[0], elements[1]]);
+        const elements = find(".test");
 
-        const results = document.getElementsByClassName("test");
-        assert.equal(results[0].innerHTML,"", "first element is empty");
-        assert.equal(results[1].innerHTML,"", "second element is empty");
+        assert.notEqual(elements[0].innerHTML, 0, "first element contains something before the empty() was executed");
+        assert.notEqual(elements[1].innerHTML, 0, "second element contains something before the empty() was executed");
+        empty(elements);
+        assert.equal(elements[0].innerHTML, "", "first element is empty");
+        assert.equal(elements[1].innerHTML, "", "second element is empty");
     }
 );
 


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

empty() with one parameter
empty() with an array of elements as a parameter
empty() with an (query) string as an element
empty() with an empty array


## Expected result

- It is expected that the empty()-function simply removes everything inside an element/many elements.

- The empty()-function should also check if the element is valid and throw an error if this is not the case.

## Current result

All tests run successfully.
