### PR TITLE
add replace() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -13,6 +13,8 @@ import "../cases/dom/traverse/not";
 import "../cases/dom/traverse/prev";
 import "../cases/dom/traverse/prevAll";
 import "../cases/dom/traverse/siblings";
+import "../cases/dom/utils/isElement";
+import "../cases/dom/utils/splitStringValue";
 import "../cases/io/file";
 import "../cases/timing/debounce";
 import "../cases/url/Slug";

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -4,6 +4,7 @@ import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";
 import "../cases/dom/manipulate/remove";
+import "../cases/dom/manipulate/replace";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";
 import "../cases/dom/traverse/find";

--- a/tests/cases/dom/manipulate/replace.js
+++ b/tests/cases/dom/manipulate/replace.js
@@ -19,17 +19,13 @@ QUnit.test(
     "with valid node elements",
     (assert) =>
     {
-        const elements = document.getElementById("qunit-fixture").children;
-        const reference = document.getElementById("test");
+        const children = document.getElementById("qunit-fixture").children;
         const replacement = document.createElement("p");
-        const index = Array.prototype.indexOf.call(elements, reference);
-        const lengthBefore = elements.length;
-        replace(reference, replacement);
+        const lengthBefore = children.length;
+        replace(children[2], replacement);
 
-        const element = elements[index];
-        assert.equal(elements.length, lengthBefore, "the amount of elements did not change");
-        assert.notEqual(element, reference, "old element does not exist anymore");
-        assert.equal(element, replacement, "element was replaced");
+        assert.equal(children.length, lengthBefore, "the amount of elements did not change");
+        assert.equal(children[2], replacement, "element was replaced");
     }
 );
 

--- a/tests/cases/dom/manipulate/replace.js
+++ b/tests/cases/dom/manipulate/replace.js
@@ -1,11 +1,12 @@
+import {createElement, replace} from "../../../../dom/manipulate";
 import QUnit from "qunitjs";
-import {replace} from "../../../../dom/manipulate";
+import {findOne} from "../../../../dom/traverse";
 
 QUnit.module("dom/manipulate/replace()",
     {
         beforeEach: () =>
         {
-            document.getElementById("qunit-fixture").innerHTML = `
+            findOne("#qunit-fixture").innerHTML = `
                 <div id="before"></div>
                 <div id="test"></div>
                 <div id="after"></div>
@@ -19,8 +20,8 @@ QUnit.test(
     "with valid node elements",
     (assert) =>
     {
-        const children = document.getElementById("qunit-fixture").children;
-        const replacement = document.createElement("p");
+        const children = findOne("#qunit-fixture").children;
+        const replacement = createElement("p");
         const lengthBefore = children.length;
         replace(children[2], replacement);
 
@@ -36,7 +37,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                replace(document.createElement("div"), "#test");
+                replace(createElement("div"), "#test");
             },
             "function threw an error"
         );
@@ -50,7 +51,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                replace(document.createElement("div"), null);
+                replace(createElement("div"), null);
             },
             "function threw an error"
         );
@@ -64,7 +65,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                replace(`<div class="replacement"></div>`, document.getElementById("test"));
+                replace(`<div class="replacement"></div>`, findOne("#test"));
             },
             "function threw an error"
         );

--- a/tests/cases/dom/manipulate/replace.js
+++ b/tests/cases/dom/manipulate/replace.js
@@ -1,0 +1,76 @@
+import QUnit from "qunitjs";
+import {replace} from "../../../../dom/manipulate";
+
+QUnit.module("dom/manipulate/replace()",
+    {
+        beforeEach: () =>
+        {
+            document.getElementById("qunit-fixture").innerHTML = `
+                <div id="before"></div>
+                <div id="test"></div>
+                <div id="after"></div>
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "with valid node elements",
+    (assert) =>
+    {
+        const elements = document.getElementById("qunit-fixture").children;
+        const reference = document.getElementById("test");
+        const replacement = document.createElement("p");
+        const index = Array.prototype.indexOf.call(elements, reference);
+        const lengthBefore = elements.length;
+        replace(reference, replacement);
+
+        const element = elements[index];
+        assert.equal(elements.length, lengthBefore, "the amount of elements did not change");
+        assert.notEqual(element, reference, "old element does not exist anymore");
+        assert.equal(element, replacement, "element was replaced");
+    }
+);
+
+
+QUnit.test(
+    "with an query string as an reference",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                replace(document.createElement("div"), "#test");
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with an invalid reference",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                replace(document.createElement("div"), null);
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "with a html string as an replacement",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                replace(`<div class="replacement"></div>`, document.getElementById("test"));
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/utils/isElement.js
+++ b/tests/cases/dom/utils/isElement.js
@@ -1,0 +1,37 @@
+import QUnit from "qunitjs";
+import {createElement} from "../../../../dom/manipulate";
+import {isElement} from "../../../../dom/utils";
+
+QUnit.module("dom/utils/isElement()");
+
+
+QUnit.test(
+    "with element as parameter",
+    (assert) =>
+    {
+        assert.ok(isElement(createElement("div")), "recognised element");
+    }
+);
+
+
+QUnit.test(
+    "with an (query) string as parameter",
+    (assert) =>
+    {
+        assert.notOk(isElement("#quint-fixture"), "recognised non-element");
+    }
+);
+
+
+QUnit.test(
+    "with an null as parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                isElement(null);
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/utils/splitStringValue.js
+++ b/tests/cases/dom/utils/splitStringValue.js
@@ -1,0 +1,56 @@
+import QUnit from "qunitjs";
+import {splitStringValue} from "../../../../dom/utils";
+
+QUnit.module("dom/utils/splitStringValue()");
+
+
+QUnit.test(
+    "with string as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue("Value1 Value2 Value3 Value4 Value5");
+
+        assert.equal(values.length, 5, "recognised all values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with array as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue(
+            ["Value1", "Value2", "Value3", "Value4", "Value5"]
+        );
+
+        assert.equal(values.length, 5, "recognised all values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with an empty string as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue("");
+
+        assert.equal(values.length, 0, "result has no values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with an null as parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                splitStringValue(null);
+            },
+            "function threw an error"
+        );
+    }
+);


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

replace() with valid node elements
replace() with an query string as an reference
replace() with an invalid reference
replace() with a html string as an replacement


## Expected result

- It is expected that the replace()-function simply replaces the reference with the replacement element.

- The replace()-function should also check if the reference or the replacement is valid and throw an error if this is not the case.

## Current result

All tests ran successfully.
