### PR TITLE
remove some variables to improve readability

### DIFF
--- a/tests/cases/dom/manipulate/append.js
+++ b/tests/cases/dom/manipulate/append.js
@@ -22,11 +22,10 @@ QUnit.test(
     {
         const parent = document.getElementById("test-parent");
         const appendingChild = document.createElement("div");
-        const className = "identifier";
-        appendingChild.classList.add(className);
+        appendingChild.classList.add("className");
         append(parent, appendingChild);
 
-        assert.equal(document.getElementsByClassName(className).length, 1, "has one occurrence");
+        assert.equal(document.getElementsByClassName("className").length, 1, "has one occurrence");
         assert.equal(parent.lastElementChild, appendingChild, "is last element");
     }
 );
@@ -37,10 +36,9 @@ QUnit.test(
     (assert) =>
     {
         const parent = document.getElementById("test-parent");
-        const className = "identifier";
-        append(parent, `<div class="${className}"></div>`);
+        append(parent, `<div class="className"></div>`);
 
-        assert.ok(parent.lastElementChild.classList.contains(className), "is last element");
+        assert.ok(parent.lastElementChild.classList.contains("className"), "is last element");
     }
 );
 
@@ -50,12 +48,11 @@ QUnit.test(
     (assert) =>
     {
         const parent = document.getElementById("test-parent");
-        const appendingChild = document.createElement("div");
-        const secondAppendingChild = document.createElement("div");
-        append(parent, [appendingChild, secondAppendingChild]);
+        const appendingChildren = [document.createElement("div"), document.createElement("div")];
+        append(parent, appendingChildren);
 
-        assert.equal(parent.children[parent.children.length - 2], appendingChild, "is second to last element");
-        assert.equal(parent.lastElementChild, secondAppendingChild, "is last element");
+        assert.equal(parent.children[2], appendingChildren[0], "is second to last element");
+        assert.equal(parent.children[3], appendingChildren[1], "is last element");
     }
 );
 

--- a/tests/cases/dom/manipulate/append.js
+++ b/tests/cases/dom/manipulate/append.js
@@ -1,11 +1,12 @@
+import {append, createElement} from "../../../../dom/manipulate";
+import {children, find, findOne} from "../../../../dom/traverse";
 import QUnit from "qunitjs";
-import {append} from "../../../../dom/manipulate";
 
 QUnit.module("dom/manipulate/append()",
     {
         beforeEach: () =>
         {
-            document.getElementById("qunit-fixture").innerHTML = `
+            findOne("#qunit-fixture").innerHTML = `
                 <div id="test-parent">
                     <div class="first"></div>
                     <div class="second"></div>
@@ -20,12 +21,11 @@ QUnit.test(
     "with node as parent and child",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const appendingChild = document.createElement("div");
-        appendingChild.classList.add("className");
+        const parent = findOne("#test-parent");
+        const appendingChild = createElement(`<div class="className"></div>`);
         append(parent, appendingChild);
 
-        assert.equal(document.getElementsByClassName("className").length, 1, "has one occurrence");
+        assert.equal(find(".className").length, 1, "has one occurrence");
         assert.equal(parent.lastElementChild, appendingChild, "is last element");
     }
 );
@@ -35,7 +35,7 @@ QUnit.test(
     "with node as parent and html string as a child",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
+        const parent = findOne("#test-parent");
         append(parent, `<div class="className"></div>`);
 
         assert.ok(parent.lastElementChild.classList.contains("className"), "is last element");
@@ -47,12 +47,13 @@ QUnit.test(
     "with node as parent and an array of nodes as children",
     (assert) =>
     {
-        const parent = document.getElementById("test-parent");
-        const appendingChildren = [document.createElement("div"), document.createElement("div")];
+        const parent = findOne("#test-parent");
+        const appendingChildren = [createElement("div"), createElement("div")];
         append(parent, appendingChildren);
 
-        assert.equal(parent.children[2], appendingChildren[0], "is second to last element");
-        assert.equal(parent.children[3], appendingChildren[1], "is last element");
+        const childElements = children(parent);
+        assert.equal(childElements[2], appendingChildren[0], "is second to last element");
+        assert.equal(childElements[3], appendingChildren[1], "is last element");
     }
 );
 
@@ -63,7 +64,7 @@ QUnit.test(
     {
         assert.throws(
             () => {
-                append(document.getElementById("test-parent"), null);
+                append(findOne("#test-parent"), null);
             },
             "function threw an error"
         );


### PR DESCRIPTION
Some variables make it unnecessarily hard to read so we should hard code the values in the test.