### PR TITLE
alter splitStringValue() function

### DIFF
--- a/dom/utils.js
+++ b/dom/utils.js
@@ -18,7 +18,11 @@ export function isElement (node)
  */
 export function splitStringValue (value)
 {
-    return Array.isArray(value)
-        ? value
+    if (Array.isArray(value))
+    {
+        return value;
+    }
+    return value === ""
+        ? []
         : value.trim().split(/ +/);
 }


### PR DESCRIPTION
to return an empty array if the given string is empty. 
This should happen because if a string with no values is used as a parameter you're going to expect no values in the array returned by the function.