### PR TITLE
add test for utls functions

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -13,6 +13,8 @@ import "../cases/dom/traverse/not";
 import "../cases/dom/traverse/prev";
 import "../cases/dom/traverse/prevAll";
 import "../cases/dom/traverse/siblings";
+import "../cases/dom/utils/isElement";
+import "../cases/dom/utils/splitStringValue";
 import "../cases/io/file";
 import "../cases/timing/debounce";
 import "../cases/url/Slug";

--- a/tests/cases/dom/utils/isElement.js
+++ b/tests/cases/dom/utils/isElement.js
@@ -1,0 +1,37 @@
+import QUnit from "qunitjs";
+import {createElement} from "../../../../dom/manipulate";
+import {isElement} from "../../../../dom/utils";
+
+QUnit.module("dom/utils/isElement()");
+
+
+QUnit.test(
+    "with element as parameter",
+    (assert) =>
+    {
+        assert.ok(isElement(createElement("div")), "recognised element");
+    }
+);
+
+
+QUnit.test(
+    "with an (query) string as parameter",
+    (assert) =>
+    {
+        assert.notOk(isElement("#quint-fixture"), "recognised non-element");
+    }
+);
+
+
+QUnit.test(
+    "with an null as parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                isElement(null);
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/utils/splitStringValue.js
+++ b/tests/cases/dom/utils/splitStringValue.js
@@ -1,0 +1,56 @@
+import QUnit from "qunitjs";
+import {splitStringValue} from "../../../../dom/utils";
+
+QUnit.module("dom/utils/splitStringValue()");
+
+
+QUnit.test(
+    "with string as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue("Value1 Value2 Value3 Value4 Value5");
+
+        assert.equal(values.length, 5, "recognised all values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with array as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue(
+            ["Value1", "Value2", "Value3", "Value4", "Value5"]
+        );
+
+        assert.equal(values.length, 5, "recognised all values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with an empty string as parameter",
+    (assert) =>
+    {
+        const values = splitStringValue("");
+
+        assert.equal(values.length, 0, "result has no values");
+        assert.ok(Array.isArray(values), "is Array");
+    }
+);
+
+
+QUnit.test(
+    "with an null as parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                splitStringValue(null);
+            },
+            "function threw an error"
+        );
+    }
+);


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

isElement() with element as parameter
isElement() with an (query) string as parameter
isElement() with an null as parameter
splitStringValue() with string as parameter
splitStringValue() with array as parameter
splitStringValue() with an empty string as parameter
splitStringValue() with an null as parameter

## Expected result

- It is expected that the isElement()-function simply checks whether a given element is an element or not.

- The isElement()-function should also check if the given parameter is valid and throw an error if this is not the case.

- The splitStringValue()-function is expected to split an string by blank spaces and return an array of values.

- The splitStringValue()-function should also check if the given parameter has values and return only values.

- The splitStringValue()-function should also check if the given parameter is valid and throw an error if this is not the case.

## Current result

All tests but one ran successfully.

At the moment the test "with an empty string as parameter" is expected to return an empty array. This is note the case. Instead of doing exactly that it returns an array with one value being an empty string.

![bildschirmfoto 2017-07-17 um 18 17 00](https://user-images.githubusercontent.com/22484446/28278096-2d486c44-6b1c-11e7-93a8-30e4c0a6db54.png)

