### PR TITLE
add clone() and duplicate() unit tests

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -1,5 +1,7 @@
 import "../cases/date/compare";
 import "../cases/date/format";
+import "../cases/dom/clone/clone";
+import "../cases/dom/clone/duplicate";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
 import "../cases/dom/manipulate/append";

--- a/tests/cases/dom/clone/clone.js
+++ b/tests/cases/dom/clone/clone.js
@@ -1,0 +1,101 @@
+import {on, trigger} from "../../../../dom/events";
+import QUnit from "qunitjs";
+import {children} from "../../../../dom/traverse";
+import {clone} from "../../../../dom/clone";
+import {createElement} from "../../../../dom/manipulate";
+import {getAttr} from "../../../../dom/attr";
+
+QUnit.module("dom/clone/clone()");
+
+QUnit.test(
+    "with created node element",
+    (assert) =>
+    {
+        const element = createElement(`
+            <div id="id" class="className.test.test2" style="display: none; visibility: hidden;" data-test="test">
+                <p class="child-1">
+                    content
+                </p>
+                <p class="child-2">
+                    other content
+                </p>
+            </div>
+        `);
+        let triggered = false;
+
+        on(element, "eventTrigger", () => {
+            triggered = true;
+        });
+
+
+        const clonedElement = clone(element);
+        trigger(clonedElement, "eventTrigger");
+
+
+        // region check whether the cloned element is a DOM element on its own
+        assert.notEqual(clonedElement, element, "elements are not one and the same element");
+        // endregion
+
+
+        // region check if event handler were cloned
+        assert.ok(triggered, `event was cloned to the new element`);
+        // endregion
+
+
+        // region check element attributes
+        for(const attribute of element.attributes)
+        {
+            assert.equal(
+                getAttr(clonedElement, attribute),
+                getAttr(element, attribute),
+                `${attribute.name}-attribute was cloned`
+            );
+        }
+        // endregion
+
+
+        // region check child elements
+        for(let i = 0; i < children(element).length; i++)
+        {
+            assert.equal(
+                children(clonedElement)[i].className,
+                children(element)[i].className,
+                "children were all cloned"
+            );
+        }
+        // endregion
+
+
+        // region check HTML structure
+        assert.equal(clonedElement.outerHTML, element.outerHTML, `outerHTML was cloned`);
+        // endregion
+    }
+);
+
+
+QUnit.test(
+    "with (query) string",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = clone("#qunit-fixture");
+            },
+            "function threw an error",
+        );
+    }
+);
+
+
+QUnit.test(
+    "with an invalid parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = clone(null);
+            },
+            "function threw an error",
+        );
+    }
+);

--- a/tests/cases/dom/clone/duplicate.js
+++ b/tests/cases/dom/clone/duplicate.js
@@ -1,0 +1,87 @@
+import QUnit from "qunitjs";
+import {children} from "../../../../dom/traverse";
+import {createElement} from "../../../../dom/manipulate";
+import {duplicate} from "../../../../dom/clone";
+import {getAttr} from "../../../../dom/attr";
+
+QUnit.module("dom/clone/duplicate()");
+
+QUnit.test(
+    "with created node element",
+    (assert) =>
+    {
+        const element = createElement(`
+            <div id="id" class="className.test.test2" style="display: none; visibility: hidden;" data-test="test">
+                <p class="child-1">
+                    content
+                </p>
+                <p class="child-2">
+                    other content
+                </p>
+            </div>
+        `);
+        const duplicatedElement = duplicate(element);
+
+
+        // region check whether the duplicated element is a DOM element on its own
+        assert.notEqual(duplicatedElement, element, "elements are not one and the same element");
+        // endregion
+
+
+        // region check element attributes
+        for(const attribute of element.attributes)
+        {
+            assert.equal(
+                getAttr(duplicatedElement, attribute),
+                getAttr(element, attribute),
+                `${attribute.name}-attribute was duplicated`
+            );
+        }
+        // endregion
+
+
+        // region check child elements
+        for(let i = 0; i < children(element).length; i++)
+        {
+            assert.equal(
+                children(duplicatedElement)[i].className,
+                children(element)[i].className,
+                "children were all duplicated"
+            );
+        }
+        // endregion
+
+
+        // region check HTML structure
+        assert.equal(duplicatedElement.outerHTML, element.outerHTML, `outerHTML was duplicated`);
+        // endregion
+    }
+);
+
+
+QUnit.test(
+    "with (query) string",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = duplicate("#qunit-fixture");
+            },
+            "function threw an error",
+        );
+    }
+);
+
+
+QUnit.test(
+    "with an invalid parameter",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                const element = duplicate(null);
+            },
+            "function threw an error",
+        );
+    }
+);


### PR DESCRIPTION
## Unit tests

The following tests are being created by this branch:

clone() with created node element
clone() with (query) string
clone() with an invalid parameter
duplicate() with created node element
duplicate() with (query) string
duplicate() with an invalid parameter


## Expected result

- It is expected that the clone()-function and the duplicate()-function copy an complete element.

- The clone()-function is also expected to copy the event-handlers

- The the clone()-function and the duplicate()-function should also check if the element is valid and throw an error if this is not the case.

## Current result

All tests run successfully.
