### PR TITLE
Add unit tests for the events functions

### DIFF
--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -1,7 +1,10 @@
 import "../cases/date/compare";
 import "../cases/date/format";
+import "../cases/dom/events/live";
+import "../cases/dom/events/off";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
+import "../cases/dom/events/trigger";
 import "../cases/dom/manipulate/append";
 import "../cases/dom/manipulate/remove";
 import "../cases/dom/traverse/children";

--- a/tests/cases/dom/events/live.js
+++ b/tests/cases/dom/events/live.js
@@ -1,0 +1,139 @@
+/* eslint-disable no-empty-function */
+
+
+import {find, findOne} from "../../../../dom/traverse";
+import {live, off, on, trigger} from "../../../../dom/events";
+import QUnit from "qunitjs";
+
+QUnit.module("dom/events/live()", {
+    beforeEach: () =>
+    {
+        findOne("#qunit-fixture").innerHTML = `
+            <div id="element">
+                <div class="child"></div>
+                <div class="child class-name"></div>
+            </div>
+        `;
+    },
+});
+
+
+QUnit.test(
+    "live()",
+    (assert) =>
+    {
+        assert.expect(2);
+        const element = findOne("#element");
+
+        const intermediate = live(element, "*", "click", () => {
+            assert.step("eventlistener could be removed after use");
+            off(element, "click", intermediate);
+        });
+
+        assert.equal(typeof intermediate, "function", "function was returned");
+
+        element.click();
+        element.click();
+    }
+);
+
+
+QUnit.test(
+    "live() with matching selector",
+    (assert) =>
+    {
+        assert.expect(2);
+
+        live(findOne("#element"), ".child", "click", () => {
+            assert.step("event triggered on child element");
+        });
+
+        find(".child").forEach((childElement) => {
+            childElement.click();
+        });
+    }
+);
+
+
+QUnit.test(
+    "live(custom event)",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = findOne("#element");
+
+        live(element, "*", "customEvent", () => {
+            assert.step("could call handler with a custom event");
+        });
+
+        trigger(element, "customEvent");
+    }
+);
+
+
+QUnit.test(
+    "live(custom event) parsing an arbitrary object",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = findOne("#element");
+        const object = {some: "object"};
+
+        live(element, "*", "customEvent", (event) => {
+            assert.equal(event.detail, object, "arbitrary object was parsed");
+        });
+
+        trigger(element, "customEvent", object);
+    }
+);
+
+
+QUnit.test(
+    "live(custom event) multiple event handler triggered by one event",
+    (assert) =>
+    {
+        const element = findOne("#element");
+        const order = ["first handler", "second handler", "third handler", "fourth handler", "fifth handler"];
+
+        order.forEach((value) => {
+            live(element, "*", "customEvent", () => {
+                assert.step(value);
+            });
+        });
+
+        trigger(element, "customEvent");
+        assert.verifySteps(order, "tests ran in the right order");
+    }
+);
+
+
+QUnit.test(
+    "live() with an invalid element",
+    (assert) =>
+    {
+        assert.throws(() => {
+            live(null, "*", "customEvent", () => {});
+        });
+    }
+);
+
+
+QUnit.test(
+    "live() with an invalid selector",
+    (assert) =>
+    {
+        live(findOne("#element"), null, "customElement", () => {});
+        assert.step("this should have worked because the behavior of the function in this case is not defined");
+    }
+);
+
+
+QUnit.test(
+    "live() with an invalid event",
+    (assert) =>
+    {
+        assert.throws(() => {
+            live(findOne("#element"), "*", null, () => {});
+        });
+    }
+);

--- a/tests/cases/dom/events/off.js
+++ b/tests/cases/dom/events/off.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-empty-function */
+
+
+import {live, off} from "../../../../dom/events";
+import QUnit from "qunitjs";
+import {createElement} from "../../../../dom/manipulate";
+
+QUnit.module("dom/events/off()");
+
+
+QUnit.test(
+    "off()",
+    (assert) =>
+    {
+        assert.expect(2);
+        const element = createElement("div");
+
+        const intermediate = live(element, "*", "click", () => {
+            assert.step("event listener was triggered");
+            off(element, "click", intermediate);
+        });
+
+        element.click();
+        element.click();
+        assert.step("event listener could be removed after use");
+    }
+);
+
+
+QUnit.test(
+    "off() with an invalid element",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                off(null, "click", () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "off() with an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                off(createElement("div"), null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);

--- a/tests/cases/dom/events/on.js
+++ b/tests/cases/dom/events/on.js
@@ -1,29 +1,23 @@
 import {on} from "../../../../dom/events";
 import QUnit from "qunitjs";
-import {findOne} from "../../../../dom/traverse";
+import {createElement} from "../../../../dom/manipulate";
 
-QUnit.module("dom/events/on()", {
-    beforeEach ()
+QUnit.module("dom/events/on()");
+
+
+QUnit.test(
+    "on(click)",
+    (assert) =>
     {
-        document.getElementById("qunit-fixture").innerHTML = `
-            <div class="example">
-                <button type="button" id="button"></button>
-                <input type="text" id="input-element">
-            </div>
-        `;
-    },
-});
+        assert.expect(1);
+        const element = createElement("div");
+        const done = assert.async();
 
+        on(element, "click", () => {
+            assert.ok(true, "event listener triggered");
+            done();
+        });
 
-QUnit.test("on(click)", (assert) => {
-    assert.expect(1);
-    const button = findOne("#button");
-    const done = assert.async();
-
-    on(button, "click", () => {
-        assert.ok(true, "event listener triggered");
-        done();
-    });
-
-    button.click();
-});
+        element.click();
+    }
+);

--- a/tests/cases/dom/events/on.js
+++ b/tests/cases/dom/events/on.js
@@ -14,7 +14,7 @@ QUnit.test(
         const done = assert.async();
 
         on(element, "click", () => {
-            assert.ok(true, "event listener triggered");
+            assert.step("event listener triggered");
             done();
         });
 

--- a/tests/cases/dom/events/on.js
+++ b/tests/cases/dom/events/on.js
@@ -1,4 +1,4 @@
-import {on} from "../../../../dom/events";
+import {off, on, trigger} from "../../../../dom/events";
 import QUnit from "qunitjs";
 import {createElement} from "../../../../dom/manipulate";
 
@@ -19,5 +19,108 @@ QUnit.test(
         });
 
         element.click();
+    }
+);
+
+
+QUnit.test(
+    "on(custom event)",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+
+        on(element, "customEvent", () => {
+            assert.step("event listener triggered");
+        });
+
+        trigger(element, "customEvent");
+    }
+);
+
+
+QUnit.test(
+    "on(custom event) parsing an arbitrary object",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+        const object = {some: "object"};
+
+        on(element, "customEvent", (event) => {
+            assert.equal(event.detail, object, "event listener triggered");
+        });
+
+        trigger(element, "customEvent", object);
+    }
+);
+
+
+QUnit.test(
+    "on(custom event) triggering the event multiple times",
+    (assert) =>
+    {
+        assert.expect(5);
+        const element = createElement("div");
+
+        on(element, "customEvent", () => {
+            assert.step("event listener triggered");
+        });
+
+        for(let i = 0; i < 5; i++)
+        {
+            trigger(element, "customEvent");
+        }
+    }
+);
+
+
+QUnit.test(
+    "on(custom event) multiple event handler triggered by one event",
+    (assert) =>
+    {
+        const element = createElement("div");
+        const order = ["first handler", "second handler", "third handler", "fourth handler", "fifth handler"];
+
+        order.forEach((value) => {
+            on(element, "customEvent", () => {
+                assert.step(value);
+            });
+        });
+
+        trigger(element, "customEvent");
+        assert.verifySteps(order, "tests ran in the right order");
+    }
+);
+
+
+QUnit.test(
+    "on(custom event) is not callable after removal",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+        const handler = () => {
+            assert.step("handler is called once");
+        };
+
+        on(element, "customEvent", handler);
+        trigger(element, "customEvent");
+        off(element, "customEvent", handler);
+        trigger(element, "customEvent");
+    }
+);
+
+
+QUnit.test(
+    "on() with an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                on(createElement("div"), null, () => {});
+            },
+            "function threw an error"
+        );
     }
 );

--- a/tests/cases/dom/events/once.js
+++ b/tests/cases/dom/events/once.js
@@ -1,51 +1,41 @@
 import {off, once} from "../../../../dom/events";
 import QUnit from "qunitjs";
-import {findOne} from "../../../../dom/traverse";
+import {createElement} from "../../../../dom/manipulate";
 
-QUnit.module("dom/events/once()", {
-    beforeEach ()
-    {
-        document.getElementById("qunit-fixture").innerHTML = `
-            <div class="example">
-                <button type="button" id="button"></button>
-                <input type="text" id="input-element">
-            </div>
-        `;
-    },
-});
+QUnit.module("dom/events/once()");
 
 
 QUnit.test("once() callback only called once", (assert) => {
     assert.expect(1);
-    const el = findOne("#button");
+    const element = createElement("div");
     const done = assert.async();
 
-    once(el, "click", () => {
+    once(element, "click", () => {
         assert.ok(true, "event listener triggered");
         done();
     });
 
-    el.click();
-    el.click();
+    element.click();
+    element.click();
 });
 
 
 QUnit.test("once() removes event listener after execution", (assert) => {
     assert.expect(3);
-    const el = findOne("#button");
+    const element = createElement("div");
     const done = assert.async();
 
-    assert.equal(el._listeners, undefined, "listeners not defined");
+    assert.equal(element._listeners, undefined, "listeners not defined");
 
-    once(el, "click", () => {});
+    once(element, "click", () => {});
 
-    assert.equal(el._listeners.click.length, 1, "1 listener registered");
+    assert.equal(element._listeners.click.length, 1, "1 listener registered");
 
-    el.click();
+    element.click();
 
     window.setTimeout(
         () => {
-            assert.equal(el._listeners.click.length, 0, "listener was successfully removed");
+            assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
             done();
         }
     );
@@ -54,20 +44,20 @@ QUnit.test("once() removes event listener after execution", (assert) => {
 
 QUnit.test("once removes event listener", (assert) => {
     assert.expect(3);
-    const el = findOne("#button");
+    const element = createElement("div");
     const done = assert.async();
 
-    assert.equal(el._listeners, undefined, "listeners not defined");
+    assert.equal(element._listeners, undefined, "listeners not defined");
 
-    once(el, "click", () => {});
+    once(element, "click", () => {});
 
-    assert.equal(el._listeners.click.length, 1, "1 listener registered");
+    assert.equal(element._listeners.click.length, 1, "1 listener registered");
 
-    el.click();
+    element.click();
 
     window.setTimeout(
         () => {
-            assert.equal(el._listeners.click.length, 0, "listener was successfully removed");
+            assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
             done();
         }
     );
@@ -77,19 +67,19 @@ QUnit.test("once removes event listener", (assert) => {
 
 QUnit.test("once() can be unregistered", (assert) => {
     assert.expect(3);
-    const el = findOne("#button");
+    const element = createElement("div");
 
-    assert.equal(el._listeners, undefined, "listeners not defined");
+    assert.equal(element._listeners, undefined, "listeners not defined");
 
-    const token = once(el, "click", () => {
+    const token = once(element, "click", () => {
         assert.ok(false, "event listener triggered although it should have been removed");
         done();
     });
 
-    assert.equal(el._listeners.click.length, 1, "1 listener registered");
+    assert.equal(element._listeners.click.length, 1, "1 listener registered");
 
-    off(el, "click", token);
-    assert.equal(el._listeners.click.length, 0, "listener was successfully removed");
+    off(element, "click", token);
+    assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
 
-    el.click();
+    element.click();
 });

--- a/tests/cases/dom/events/once.js
+++ b/tests/cases/dom/events/once.js
@@ -5,81 +5,96 @@ import {createElement} from "../../../../dom/manipulate";
 QUnit.module("dom/events/once()");
 
 
-QUnit.test("once() callback only called once", (assert) => {
-    assert.expect(1);
-    const element = createElement("div");
-    const done = assert.async();
+QUnit.test(
+    "once() callback only called once",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+        const done = assert.async();
 
-    once(element, "click", () => {
-        assert.ok(true, "event listener triggered");
-        done();
-    });
-
-    element.click();
-    element.click();
-});
-
-
-QUnit.test("once() removes event listener after execution", (assert) => {
-    assert.expect(3);
-    const element = createElement("div");
-    const done = assert.async();
-
-    assert.equal(element._listeners, undefined, "listeners not defined");
-
-    once(element, "click", () => {});
-
-    assert.equal(element._listeners.click.length, 1, "1 listener registered");
-
-    element.click();
-
-    window.setTimeout(
-        () => {
-            assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
+        once(element, "click", () => {
+            assert.ok(true, "event listener triggered");
             done();
-        }
-    );
-});
+        });
+
+        element.click();
+        element.click();
+    }
+);
 
 
-QUnit.test("once removes event listener", (assert) => {
-    assert.expect(3);
-    const element = createElement("div");
-    const done = assert.async();
+QUnit.test(
+    "once() removes event listener after execution",
+    (assert) =>
+    {
+        assert.expect(3);
+        const element = createElement("div");
+        const done = assert.async();
 
-    assert.equal(element._listeners, undefined, "listeners not defined");
+        assert.equal(element._listeners, undefined, "listeners not defined");
 
-    once(element, "click", () => {});
+        once(element, "click", () => {});
 
-    assert.equal(element._listeners.click.length, 1, "1 listener registered");
+        assert.equal(element._listeners.click.length, 1, "1 listener registered");
 
-    element.click();
+        element.click();
 
-    window.setTimeout(
-        () => {
-            assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
+        window.setTimeout(
+            () => {
+                assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
+                done();
+            }
+        );
+    }
+);
+
+
+QUnit.test(
+    "once removes event listener",
+    (assert) =>
+    {
+        assert.expect(3);
+        const element = createElement("div");
+        const done = assert.async();
+
+        assert.equal(element._listeners, undefined, "listeners not defined");
+
+        once(element, "click", () => {});
+
+        assert.equal(element._listeners.click.length, 1, "1 listener registered");
+
+        element.click();
+
+        window.setTimeout(
+            () => {
+                assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
+                done();
+            }
+        );
+    }
+);
+
+
+QUnit.test(
+    "once() can be unregistered",
+    (assert) =>
+    {
+        assert.expect(3);
+        const element = createElement("div");
+
+        assert.equal(element._listeners, undefined, "listeners not defined");
+
+        const token = once(element, "click", () => {
+            assert.ok(false, "event listener triggered although it should have been removed");
             done();
-        }
-    );
-});
+        });
 
+        assert.equal(element._listeners.click.length, 1, "1 listener registered");
 
+        off(element, "click", token);
+        assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
 
-QUnit.test("once() can be unregistered", (assert) => {
-    assert.expect(3);
-    const element = createElement("div");
-
-    assert.equal(element._listeners, undefined, "listeners not defined");
-
-    const token = once(element, "click", () => {
-        assert.ok(false, "event listener triggered although it should have been removed");
-        done();
-    });
-
-    assert.equal(element._listeners.click.length, 1, "1 listener registered");
-
-    off(element, "click", token);
-    assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
-
-    element.click();
-});
+        element.click();
+    }
+);

--- a/tests/cases/dom/events/once.js
+++ b/tests/cases/dom/events/once.js
@@ -1,4 +1,4 @@
-import {off, once} from "../../../../dom/events";
+import {off, once, trigger} from "../../../../dom/events";
 import QUnit from "qunitjs";
 import {createElement} from "../../../../dom/manipulate";
 
@@ -20,6 +20,25 @@ QUnit.test(
 
         element.click();
         element.click();
+    }
+);
+
+
+QUnit.test(
+    "once() called with custom event",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+        const done = assert.async();
+
+        once(element, "customEvent", () => {
+            assert.step("event listener triggered");
+            done();
+        });
+
+        trigger(element, "customEvent");
+        trigger(element, "customEvent");
     }
 );
 
@@ -51,7 +70,7 @@ QUnit.test(
 
 
 QUnit.test(
-    "once removes event listener",
+    "once() removes event listener",
     (assert) =>
     {
         assert.expect(3);
@@ -95,5 +114,70 @@ QUnit.test(
         assert.equal(element._listeners.click.length, 0, "listener was successfully removed");
 
         element.click();
+    }
+);
+
+
+QUnit.test(
+    "once(custom event) parsing an arbitrary object",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+        const object = {some: "object"};
+
+        once(element, "customEvent", (event) => {
+            assert.equal(event.detail, object, "event listener triggered");
+        });
+
+        trigger(element, "customEvent", object);
+    }
+);
+
+
+QUnit.test(
+    "once(custom event) multiple event handler triggered by one event",
+    (assert) =>
+    {
+        assert.expect(6);
+        const element = createElement("div");
+        const order = ["first handler", "second handler", "third handler", "fourth handler", "fifth handler"];
+
+        order.forEach((value) => {
+            once(element, "customEvent", () => {
+                assert.step(value);
+            });
+        });
+
+        trigger(element, "customEvent");
+        assert.verifySteps(order, "tests ran in the right order");
+    }
+);
+
+
+QUnit.test(
+    "once() with an invalid element",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                once(null, "customEvent", () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "once() with an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                once(createElement("div"), null, () => {});
+            },
+            "function throws an error"
+        );
     }
 );

--- a/tests/cases/dom/events/once.js
+++ b/tests/cases/dom/events/once.js
@@ -14,7 +14,7 @@ QUnit.test(
         const done = assert.async();
 
         once(element, "click", () => {
-            assert.ok(true, "event listener triggered");
+            assert.step("event listener triggered");
             done();
         });
 
@@ -86,8 +86,7 @@ QUnit.test(
         assert.equal(element._listeners, undefined, "listeners not defined");
 
         const token = once(element, "click", () => {
-            assert.ok(false, "event listener triggered although it should have been removed");
-            done();
+            assert.step("event listener triggered although it should have been removed");
         });
 
         assert.equal(element._listeners.click.length, 1, "1 listener registered");

--- a/tests/cases/dom/events/once.js
+++ b/tests/cases/dom/events/once.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle, no-empty-function */
+
 import {off, once, trigger} from "../../../../dom/events";
 import QUnit from "qunitjs";
 import {createElement} from "../../../../dom/manipulate";

--- a/tests/cases/dom/events/trigger.js
+++ b/tests/cases/dom/events/trigger.js
@@ -1,0 +1,61 @@
+import QUnit from "qunitjs";
+import {createElement} from "../../../../dom/manipulate";
+import {on, trigger} from "../../../../dom/events";
+
+QUnit.module("dom/events/trigger()");
+
+
+QUnit.test(
+    "trigger() with an click event",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+
+        on(element, "click", () => {
+            assert.step("event listener was triggered");
+        });
+
+        trigger(element, "click");
+    }
+);
+
+
+QUnit.test(
+    "trigger() with a custom event",
+    (assert) =>
+    {
+        assert.expect(1);
+        const element = createElement("div");
+
+        on(element, "customEvent", () => {
+            assert.step("event listener was triggered");
+        });
+
+        trigger(element, "customEvent");
+    }
+);
+
+
+QUnit.test(
+    "trigger() with an invalid element",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                trigger(null, "click");
+            },
+            "function threw an error"
+        );
+    }
+);
+
+
+QUnit.test(
+    "trigger() with an invalid event",
+    (assert) =>
+    {
+        trigger(createElement("div"), null);
+        assert.step("this should have worked because the behavior of the function in this case is not defined");
+    }
+);


### PR DESCRIPTION
# Unit tests

The following tests are being created by this branch:

## live()-function

### Test cases

live()
live() with matching selector
live(custom event)
live(custom event) parsing an arbitrary object
live(custom event) multiple event handler triggered by one event
live() with an invalid element
live() with an invalid selector
live() with an invalid event

### Expected result

- It is expected that the live()-function creates an event listener on the given element, with the given event type, the given selector and the given event handler. The event handler should be returned by the live()-function as well.



## off()-function

### Test cases

off()
off() with an invalid element
off() with an invalid event

### Expected result

- The off()-function should remove an event listener on the given element, with the given event type and the given event handler.



## on()-function

### Test cases

on(click)
on(custom event)
on(custom event) parsing an arbitrary object
on(custom event) triggering the event multiple times
on(custom event) multiple event handler triggered by one event
on(custom event) is not callable after removal
on() with an invalid event

### Expected result

- It is expected that the on()-function creates an event listener on the given element, with the given event type and the given event handler.



### once()-function

### Test cases

once() callback only called once
once() called with custom event
once() removes event listener after execution
once() removes event listener
once() can be unregistered
once(custom event) parsing an arbitrary object
once(custom event) multiple event handler triggered by one event
once() with an invalid element
once() with an invalid event

### Expected result

- It is expected that the once()-function creates an event listener on the given element, with the given event type and the given event handler. The event handler should be returned by the live()-function as well.



### trigger()-function

### Test cases

trigger() with an click event
trigger() with a custom event
trigger() with an invalid element
trigger() with an invalid event

### Expected result

- The trigger()-function should trigger an event on the given element.

# Current results

All tests run successfully.

