### PR TITLE
Add live test for a non-matching child

### DIFF
--- a/tests/cases/dom/events/live.js
+++ b/tests/cases/dom/events/live.js
@@ -56,6 +56,23 @@ QUnit.test(
 
 
 QUnit.test(
+    "live() with non-matching selector",
+    (assert) =>
+    {
+        live(findOne("#element"), ".not-matching-class", "click", () => {
+            assert.step("event triggered on child element");
+        });
+
+        find(".child").forEach((childElement) => {
+            childElement.click();
+        });
+
+        assert.verifySteps([], "no handler was triggered on the non-matching children");
+    }
+);
+
+
+QUnit.test(
     "live(custom event)",
     (assert) =>
     {

--- a/tests/cases/dom/events/live.js
+++ b/tests/cases/dom/events/live.js
@@ -2,7 +2,7 @@
 
 
 import {find, findOne} from "../../../../dom/traverse";
-import {live, off, on, trigger} from "../../../../dom/events";
+import {live, off, trigger} from "../../../../dom/events";
 import QUnit from "qunitjs";
 
 QUnit.module("dom/events/live()", {


### PR DESCRIPTION
## Unit test

The following test is being created by this branch:

live() with non-matching selector

## Expected result

- No handler should be triggered by the event

## Current result

The test run successfully.

Fixes #56 