### PR TITLE
add string/manipulate/replaceAll function

### DIFF
--- a/string/manipulate.js
+++ b/string/manipulate.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {{
+ *      string: string,
+ * }|Object} mojave.replacementStringObject
+ */
+
+
+/**
+ * Replaces all occurrences of a given matching string with a given replacement string
+ *
+ * @param {string}                         text
+ * @param {mojave.replacementStringObject} replacements
+ *
+ * @returns {string}
+ */
+export function replaceAll (text, replacements)
+{
+    for (const key in replacements)
+    {
+        if (!replacements.hasOwnProperty(key))
+        {
+            continue;
+        }
+
+        text = text.split(key).join(replacements[key]);
+    }
+
+    return text;
+}

--- a/string/manipulate.js
+++ b/string/manipulate.js
@@ -1,15 +1,8 @@
 /**
- * @typedef {{
- *      string: string,
- * }|Object} mojave.replacementStringObject
- */
-
-
-/**
- * Replaces all occurrences of a given matching string with a given replacement string
+ * Replaces all occurrences of substrings in the given string.
  *
- * @param {string}                         text
- * @param {mojave.replacementStringObject} replacements
+ * @param {string}                text
+ * @param {Object<string,string>} replacements
  *
  * @returns {string}
  */

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -30,6 +30,7 @@ import "../cases/dom/utils/isElement";
 import "../cases/dom/utils/splitStringValue";
 import "../cases/extend/merge";
 import "../cases/io/file";
+import "../cases/string/manipulate/replaceAll";
 import "../cases/timing/debounce";
 import "../cases/url/Slug";
 

--- a/tests/cases/string/manipulate/replaceAll.js
+++ b/tests/cases/string/manipulate/replaceAll.js
@@ -1,0 +1,125 @@
+import QUnit from "qunitjs";
+import {replaceAll} from "../../../../string/manipulate";
+
+QUnit.module("string/manipulate/replaceAll()");
+
+
+QUnit.test(
+    "replace string with 1 occurrence of 1 replacement string",
+    (assert) =>
+    {
+        let text = "foobar";
+        text = replaceAll(text, {foo: "a"});
+
+        assert.equal(text, "abar", `string was successfully replaced`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with 1 occurrence of each replacement sting",
+    (assert) =>
+    {
+        let text = "foobar";
+        text = replaceAll(text, {foo: "a", bar: "b"});
+
+        assert.equal(text, "ab", `string was successfully replaced`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with multiple occurrences of each replacement sting",
+    (assert) =>
+    {
+        let text = "foobarbarfoofoobarfoobar";
+        text = replaceAll(text, {foo: "a", bar: "b"});
+
+        assert.equal(text, "abbaabab", `string was successfully replaced`);
+    }
+);
+
+
+QUnit.test(
+    "replace string without matching replacement strings",
+    (assert) =>
+    {
+        let text = "farboo";
+        text = replaceAll(text, {foo: "a", bar: "b"});
+
+        assert.equal(text, "farboo", `string is unaltered`);
+    }
+);
+
+
+QUnit.test(
+    "replace string without replacement strings",
+    (assert) =>
+    {
+        let text = "farboo";
+        text = replaceAll(text, {});
+
+        assert.equal(text, "farboo", `string is unaltered`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with null as replacement strings",
+    (assert) =>
+    {
+        let text = "foobar";
+        text = replaceAll(text, {bar: null});
+
+        assert.equal(text, "foonull", `string was successfully replaced`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with null as replacement strings",
+    (assert) =>
+    {
+        let text = "foobar";
+        text = replaceAll(text, {null: null});
+
+        assert.equal(text, "foobar", `string is unaltered`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with empty string as matching string",
+    (assert) =>
+    {
+        let text = "foo";
+        text = replaceAll(text, {"": "x"});
+
+        assert.equal(text, "fxoxo", `string was successfully replaced. The result has a the replacement string after every character`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with regex as matching string",
+    (assert) =>
+    {
+        let text = "foobar";
+        const regx = /(foo)/g;
+        text = replaceAll(text, {[regx]: "x"});
+
+        assert.equal(text, "foobar", `string is unaltered`);
+    }
+);
+
+
+QUnit.test(
+    "replace string with matching string, which matches after first iteration",
+    (assert) =>
+    {
+        let text = "fooar";
+        text = replaceAll(text, {foo: "b", bar: "a"});
+
+        assert.equal(text, "a", `string was successfully replaced. The result is a string, which matched only after the first alteration, which lead the string to be replaced although it wouldn't have been replaced if the original string was matched against.`);
+    }
+);


### PR DESCRIPTION
As mentioned in the following issue https://github.com/Becklyn/mojave/issues/61 a replaceAll() function would be rather handy.
The replaceAll() function does not support RegExp as an matching string due to performance reasons.