### PR TITLE
Avoid rejecting animation director promise

### DIFF
--- a/animation.js
+++ b/animation.js
@@ -11,7 +11,7 @@
  *      easing: function(number):number,
  *      duration: number,
  *      ?stopPrevious: boolean,
- *      onAnimationFinished: function(),
+ *      onAnimationFinished: function(boolean),
  * }} mojave.AnimationContext
  *
  * @typedef {{
@@ -114,10 +114,8 @@ export function animateCallback (callback, options = {})
     context.currentFrame = null;
 
     // Build animation director + promise
-    let onAnimationAborted;
     const animationDirector = new Promise((resolve, reject) => {
         context.onAnimationFinished = resolve;
-        onAnimationAborted = reject;
     });
 
     // register first animation frame
@@ -128,7 +126,7 @@ export function animateCallback (callback, options = {})
     // add stop() method to animation director (the context needs to be initialized)
     animationDirector.stop = () =>
     {
-        onAnimationAborted();
+        context.onAnimationFinished(false);
         window.cancelAnimationFrame(context.currentFrame);
     };
 
@@ -159,7 +157,7 @@ function runAnimationStep (time, start, callback, context)
     }
     else
     {
-        context.onAnimationFinished();
+        context.onAnimationFinished(true);
     }
 }
 


### PR DESCRIPTION
We’re now always resolving to prevent any promise chain errors bubbling into user land code since it’s an expected code and not an exception.

Instead of cancelling the promise with `undefined`, we’re resolving with an new `mojave.AnimationResult` object that represents various states