### PR TITLE
Added fistChild

### DIFF
--- a/dom/traverse.js
+++ b/dom/traverse.js
@@ -169,6 +169,32 @@ export function children (parent, selector = null)
 
 
 /**
+ * Returns the first child
+ *
+ * @param {HTMLElement} parent
+ * @param {string|null} [selector]
+ *
+ * @returns {HTMLElement}
+ */
+export function firstChild (parent, selector = null)
+{
+    let child = parent.firstElementChild;
+
+    while (child)
+    {
+        if (elementMatches(child, selector))
+        {
+            return child;
+        }
+
+        child = child.nextElementSibling;
+    }
+
+    return null;
+}
+
+
+/**
  * Returns the nearest previous sibling matching
  * (optionally matching the given selector)
  *

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -19,6 +19,7 @@ import "../cases/dom/manipulate/replace";
 import "../cases/dom/traverse/children";
 import "../cases/dom/traverse/filter";
 import "../cases/dom/traverse/find";
+import "../cases/dom/traverse/firstChild";
 import "../cases/dom/traverse/next";
 import "../cases/dom/traverse/nextAll";
 import "../cases/dom/traverse/not";

--- a/tests/cases/dom/traverse/firstChild.js
+++ b/tests/cases/dom/traverse/firstChild.js
@@ -1,0 +1,51 @@
+import {firstChild, findOne} from "../../../../dom/traverse";
+import QUnit from "qunit";
+
+QUnit.module("dom/traverse/firstChild()",
+    {
+        beforeEach: () =>
+        {
+            findOne("#qunit-fixture").innerHTML = `
+                <div class="element1"></div>
+                <div class="element2"></div>
+                Test123
+            `;
+        },
+    }
+);
+
+
+QUnit.test(
+    "firstChild() without selector",
+    (assert) =>
+    {
+        const fixture = findOne("#qunit-fixture");
+
+        const result = firstChild(fixture);
+        assert.ok(result.classList.contains("element1"), "contains .element1");
+    }
+);
+
+
+QUnit.test(
+    "firstChild() with selector matching two elements",
+    (assert) =>
+    {
+        const fixture = findOne("#qunit-fixture");
+
+        const result = firstChild(fixture, "div");
+        assert.ok(result.classList.contains("element1"), "the match has the correct class");
+    }
+);
+
+
+QUnit.test(
+    "firstChild() with selector",
+    (assert) =>
+    {
+        const fixture = findOne("#qunit-fixture");
+
+        const result = firstChild(fixture, ".element2");
+        assert.ok(result.classList.contains("element2"), "the match has the correct class");
+    }
+);


### PR DESCRIPTION
This is more or less a shortcut for doing `children(parent, selector)[0] || null`, which is easier to read and integrates more nicely with the rest of the mojave API.