### PR TITLE
Add `extend()`

### DIFF
--- a/extend.js
+++ b/extend.js
@@ -70,3 +70,30 @@ export function merge (target, ...sources)
     //      - if the types don't match
     return target;
 }
+
+
+/**
+ * Extends the component without mutating any of the sources.
+ * Is basically a shallow object copy.
+ *
+ * @param {Object[]} sources
+ * @returns {Object}
+ */
+export function extend (...sources)
+{
+    let target = {};
+
+    for (let i = 0; i < sources.length; i++) {
+        let source = sources[i];
+
+        for (const key in source)
+        {
+            if (source.hasOwnProperty(key))
+            {
+                target[key] = source[key];
+            }
+        }
+    }
+
+    return target;
+}

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -29,6 +29,7 @@ import "../cases/dom/traverse/prevAll";
 import "../cases/dom/traverse/siblings";
 import "../cases/dom/utils/isElement";
 import "../cases/dom/utils/splitStringValue";
+import "../cases/extend/extend";
 import "../cases/extend/merge";
 import "../cases/io/file";
 import "../cases/string/manipulate/replaceAll";

--- a/tests/cases/extend/extend.js
+++ b/tests/cases/extend/extend.js
@@ -1,0 +1,118 @@
+import QUnit from "qunit";
+import {extend} from "../../../extend";
+
+QUnit.module("extend/extend()");
+
+
+QUnit.test(
+    "basic extend() tests",
+    (assert) => {
+        const cases = [
+            {
+                target: {a: "a"},
+                sources: [],
+                expected: {a: "a"},
+            },
+            {
+                target: {a: 1},
+                sources: [{b: 2}],
+                expected: {
+                    a: 1,
+                    b: 2,
+                },
+            },
+            {
+                target: {
+                    a: 1,
+                    b: 2,
+                },
+                sources: [{b: 3}],
+                expected: {
+                    a: 1,
+                    b: 3,
+                },
+            },
+            {
+                target: {
+                    a: 1,
+                    b: ["a"],
+                },
+                sources: [{
+                    c: 4,
+                    b: ["b"],
+                }],
+                expected: {
+                    a: 1,
+                    b: ["b"],
+                    c: 4,
+                },
+            },
+            {
+                target: {
+                    a: 1,
+                    b: {
+                        c: 4,
+                        d: 5,
+                    },
+                    f: true,
+                },
+                sources: [{
+                    b: {
+                        c: 6,
+                        e: 7,
+                    },
+                    f: false,
+                }],
+                expected: {
+                    a: 1,
+                    b: {
+                        c: 6,
+                        e: 7,
+                    },
+                    f: false,
+                },
+            },
+            {
+                target: {
+                    a: 1,
+                    b: 2,
+                },
+                sources: [{b: 3}, {b: 5}],
+                expected: {
+                    a: 1,
+                    b: 5,
+                },
+            },
+            {
+                target: {
+                    a: 1,
+                },
+                sources: [{a: null}],
+                expected: {
+                    a: null,
+                },
+            },
+            {
+                target: {
+                    a: null,
+                },
+                sources: [{a: 1}],
+                expected: {
+                    a: 1,
+                },
+            },
+            // even invalid types are supported
+            {
+                target: {
+                    a: 1,
+                },
+                sources: [{a: [1, 2, 3]}],
+                expected: {a: [1, 2, 3]},
+            },
+        ];
+
+        cases.forEach((data, index) => {
+            assert.deepEqual(extend(data.target, ...data.sources), data.expected, `Testcase ${index}`);
+        });
+    }
+);


### PR DESCRIPTION
as shallow object copy