### PR TITLE
Don’t keep prepending elements to the same array for every additional element found

### DIFF
--- a/mount.ts
+++ b/mount.ts
@@ -17,8 +17,7 @@ export function mount (
 
     for (let i = 0; i < elements.length; i++)
     {
-        constructorParameters.unshift(elements[i]);
-        const mounted = new ComponentToMount(...constructorParameters);
+        const mounted = new ComponentToMount(elements[i], ...constructorParameters);
         mounted.init();
     }
 }

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -34,6 +34,7 @@ import "../cases/dom/utils/splitStringValue";
 import "../cases/extend/extend";
 import "../cases/extend/merge";
 import "../cases/io/file";
+import "../cases/mount/mount";
 import "../cases/string/manipulate/replaceAll";
 import "../cases/timing/debounce";
 import "../cases/types/typeOf";

--- a/tests/cases/mount/mount.js
+++ b/tests/cases/mount/mount.js
@@ -14,7 +14,7 @@ QUnit.module("mount()", {
 });
 
 QUnit.test(
-    "mount() tests",
+    "mount() test that the correct parameters are passed, fixes #158",
     (assert) =>
     {
         let context = findOne("#qunit-fixture");

--- a/tests/cases/mount/mount.js
+++ b/tests/cases/mount/mount.js
@@ -1,0 +1,56 @@
+import {findOne} from "../../../dom/traverse";
+import QUnit from "qunit";
+import {mount} from "../../../mount";
+
+QUnit.module("mount()", {
+    beforeEach: () =>
+    {
+        findOne("#qunit-fixture").innerHTML = `
+            <div id="fixture-1" class="fixture"></div>
+            <div id="fixture-2" class="fixture"></div>
+            <div id="fixture-3" class="fixture"></div>
+        `;
+    },
+});
+
+QUnit.test(
+    "mount() tests",
+    (assert) =>
+    {
+        let context = findOne("#qunit-fixture");
+        let counter = 0;
+
+        let expectedArguments = [
+            {
+                0: findOne("#fixture-1", context),
+                1: 42,
+            },
+            {
+                0: findOne("#fixture-2", context),
+                1: 42,
+            },
+            {
+                0: findOne("#fixture-3", context),
+                1: 42,
+            },
+        ];
+
+        let getExpectedArguments = () => {
+            let args = expectedArguments[counter];
+            counter++;
+            return args;
+        };
+
+        class ExampleMountComponent
+        {
+            constructor (firstParam, secondParam)
+            {
+                assert.deepEqual(arguments, getExpectedArguments())
+            }
+
+            init () {}
+        }
+
+        mount(".fixture", ExampleMountComponent, [42], context);
+    }
+);


### PR DESCRIPTION
Given the following example

```js
mount(".selector", AppComponent, [someParam]);
```

with two matching elements, the mojave would call the `AppComponent`'s constructor with the following args:
- first iteration: `firstMatchingElement, someParam`
- second iteration: `secondMatchingElement, firstMatchingElement, someParam`
- third iteration: `thirdMatchingElement, secondMatchingElement, firstMatchingElement, someParam`

And it would just continue like that as we've kept prepending the elements with each additional match. 