### PR TITLE
Use generic type parameter instead of very broad/„generic” return types

### DIFF
--- a/dom/clone.ts
+++ b/dom/clone.ts
@@ -5,9 +5,9 @@ import {getAllListeners, on} from "./events";
 /**
  * Duplicates the given DOM node
  */
-export function duplicate (element : HTMLElement) : HTMLElement
+export function duplicate<T extends HTMLElement = HTMLElement> (element : T) : T
 {
-    return element.cloneNode(true) as HTMLElement;
+    return element.cloneNode(true) as T;
 }
 
 
@@ -15,9 +15,9 @@ export function duplicate (element : HTMLElement) : HTMLElement
  * Clones the given node, that includes duplicating the node and copying
  * all data and events.
  */
-export function clone (element : HTMLElement) : HTMLElement
+export function clone<T extends HTMLElement = HTMLElement> (element : T) : T
 {
-    const clonedElement = duplicate(element);
+    const clonedElement = duplicate<T>(element);
     const listeners = getAllListeners(element);
     const dataset = element.dataset;
     const customDataset = getAllCustomData(element);

--- a/dom/manipulate.ts
+++ b/dom/manipulate.ts
@@ -24,12 +24,8 @@ export type InsertableElement = string | Element | Element[];
 
 /**
  * Parses the HTML to an HTMLElement
- *
- * @private
- * @param {string} html
- * @returns {HTMLElement}
  */
-function parseHtml<T extends HTMLElement = HTMLElement> (html : string) : T
+function parseHtml (html : string) : HTMLElement
 {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
@@ -40,7 +36,7 @@ function parseHtml<T extends HTMLElement = HTMLElement> (html : string) : T
         throw new Error("Can only parse HTML with exactly one valid root element. A valid element can stand on its own in the body.");
     }
 
-    return children[0] as T;
+    return children[0] as HTMLElement;
 }
 
 
@@ -68,7 +64,7 @@ export function createElement<T extends HTMLElement = HTMLElement> (type : strin
 export function createUnstyledElement<T extends HTMLElement = HTMLElement> (type : string, attributes : CreateUnstyledElementOptions = {}) : T
 {
     const element = (-1 !== type.indexOf("<"))
-        ? parseHtml<T>(type)
+        ? parseHtml(type) as T
         : document.createElement(type) as T;
 
     setAttrs(element, attributes);

--- a/dom/manipulate.ts
+++ b/dom/manipulate.ts
@@ -29,7 +29,7 @@ export type InsertableElement = string | Element | Element[];
  * @param {string} html
  * @returns {HTMLElement}
  */
-function parseHtml (html : string) : HTMLElement
+function parseHtml<T extends HTMLElement = HTMLElement> (html : string) : T
 {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
@@ -40,16 +40,16 @@ function parseHtml (html : string) : HTMLElement
         throw new Error("Can only parse HTML with exactly one valid root element. A valid element can stand on its own in the body.");
     }
 
-    return children[0] as HTMLElement;
+    return children[0] as T;
 }
 
 
 /**
  * Creates an element with the given attributes
  */
-export function createElement (type : string, attributes : CreateElementOptions = {}) : HTMLElement
+export function createElement<T extends HTMLElement = HTMLElement> (type : string, attributes : CreateElementOptions = {}) : T
 {
-    const element = createUnstyledElement(type, attributes);
+    const element = createUnstyledElement<T>(type, attributes);
 
     if (attributes.css !== undefined)
     {
@@ -65,11 +65,11 @@ export function createElement (type : string, attributes : CreateElementOptions 
  *
  * This is a smaller alternative to `createElement`, if you definitely don't need to style the element.
  */
-export function createUnstyledElement (type : string, attributes : CreateUnstyledElementOptions = {}) : HTMLElement
+export function createUnstyledElement<T extends HTMLElement = HTMLElement> (type : string, attributes : CreateUnstyledElementOptions = {}) : T
 {
     const element = (-1 !== type.indexOf("<"))
-        ? parseHtml(type)
-        : document.createElement(type);
+        ? parseHtml<T>(type)
+        : document.createElement(type) as T;
 
     setAttrs(element, attributes);
 

--- a/dom/traverse.ts
+++ b/dom/traverse.ts
@@ -14,17 +14,17 @@ function elementMatches (element : Element, selector : string|null = null)
 /**
  * Fetches all siblings
  */
-function fetchAllSiblings (element : Element, selector : null|string, accessor : string) : HTMLElement[]
+function fetchAllSiblings<T extends HTMLElement = HTMLElement> (element : Element, selector : null|string, accessor : string) : T[]
 {
     let indexableElement = element as mojave.types.StringIndexedHTMLElement;
     let sibling = indexableElement[accessor];
-    const list = [];
+    const list: T[] = [];
 
     while (sibling)
     {
         if (elementMatches(sibling, selector))
         {
-            list.push(sibling);
+            list.push(sibling as T);
         }
 
         sibling = sibling[accessor];
@@ -37,7 +37,7 @@ function fetchAllSiblings (element : Element, selector : null|string, accessor :
 /**
  * Fetches a single sibling
  */
-function fetchSingleSibling (element : HTMLElement, selector : null|string, accessor : string) : null|HTMLElement
+function fetchSingleSibling<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string, accessor : string) : null|T
 {
     let indexableElement = element as mojave.types.StringIndexedHTMLElement;
     let sibling = indexableElement[accessor];
@@ -46,7 +46,7 @@ function fetchSingleSibling (element : HTMLElement, selector : null|string, acce
     {
         if (elementMatches(sibling, selector))
         {
-            return sibling;
+            return sibling as T;
         }
 
         sibling = sibling[accessor];
@@ -59,29 +59,29 @@ function fetchSingleSibling (element : HTMLElement, selector : null|string, acce
 /**
  * Finds all DOM elements matching the selector
  */
-export function find (selector : string, context : HTMLElement|Document = document) : HTMLElement[]
+export function find<T extends HTMLElement = HTMLElement> (selector : string, context : HTMLElement|Document = document) : T[]
 {
-    return Array.prototype.slice.call(context.querySelectorAll(selector));
+    return Array.prototype.slice.call(context.querySelectorAll(selector)) as T[];
 }
 
 
 /**
  * Finds a single DOM node matching the selector
  */
-export function findOne (selector : string, context : HTMLElement|Document = document) : null|HTMLElement
+export function findOne<T extends HTMLElement = HTMLElement> (selector : string, context : HTMLElement|Document = document) : null|T
 {
-    return context.querySelector(selector);
+    return context.querySelector(selector) as T;
 }
 
 
 /**
  * Filters a list of DOM elements that match the given selector
  */
-export function filter (list : HTMLElement[], selector : string) : HTMLElement[]
+export function filter<T extends HTMLElement = HTMLElement> (list : HTMLElement[], selector : string) : T[]
 {
     return list.filter(
         (e) => e.matches(selector)
-    );
+    ) as T[];
 }
 
 
@@ -89,53 +89,53 @@ export function filter (list : HTMLElement[], selector : string) : HTMLElement[]
  * Filters a list of DOM elements that DO NOT match the given selector,
  * are not the given node or are not in the given node list.
  */
-export function not (list : HTMLElement[], selector : string|HTMLElement|HTMLElement[]) : HTMLElement[]
+export function not<T extends HTMLElement = HTMLElement> (list : HTMLElement[], selector : string|HTMLElement|HTMLElement[]) : T[]
 {
     if (typeof selector === "string")
     {
         return list.filter(
             (e) => !e.matches(selector)
-        );
+        ) as T[];
     }
     else if (Array.isArray(selector))
     {
         return list.filter(
             (e) => -1 !== selector.indexOf(e)
-        );
+        ) as T[];
     }
 
     return list.filter(
         (e) => e !== selector
-    );
+    ) as T[];
 }
 
 
 /**
  * Returns all children
  */
-export function children (parent : HTMLElement, selector : null|string = null) : HTMLElement[]
+export function children<T extends HTMLElement = HTMLElement> (parent : HTMLElement, selector : null|string = null) : T[]
 {
-    const list : HTMLElement[] = [];
+    const list : T[] = [];
     let child = parent.firstElementChild;
 
     while (child)
     {
         if (elementMatches(child, selector))
         {
-            list.push(child as HTMLElement);
+            list.push(child as T);
         }
 
         child = child.nextElementSibling;
     }
 
-    return list;
+    return list as T[];
 }
 
 
 /**
  * Returns the first child
  */
-export function firstChild (parent : HTMLElement, selector : null|string = null) : null|HTMLElement
+export function firstChild<T extends HTMLElement = HTMLElement> (parent : HTMLElement, selector : null|string = null) : null|T
 {
     let child = parent.firstElementChild;
 
@@ -143,7 +143,7 @@ export function firstChild (parent : HTMLElement, selector : null|string = null)
     {
         if (elementMatches(child, selector))
         {
-            return child as HTMLElement;
+            return child as T;
         }
 
         child = child.nextElementSibling;
@@ -157,9 +157,9 @@ export function firstChild (parent : HTMLElement, selector : null|string = null)
  * Returns the nearest previous sibling matching
  * (optionally matching the given selector)
  */
-export function prev (element : HTMLElement, selector : null|string = null) : null|HTMLElement
+export function prev<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string = null) : null|T
 {
-    return fetchSingleSibling(element, selector, "previousElementSibling");
+    return fetchSingleSibling<T>(element, selector, "previousElementSibling");
 }
 
 
@@ -167,9 +167,9 @@ export function prev (element : HTMLElement, selector : null|string = null) : nu
  * Returns the nearest following sibling
  * (optionally matching the given selector)
  */
-export function next (element : HTMLElement, selector : null|string = null) : null|HTMLElement
+export function next<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string = null) : null|T
 {
-    return fetchSingleSibling(element, selector, "nextElementSibling");
+    return fetchSingleSibling<T>(element, selector, "nextElementSibling");
 }
 
 
@@ -179,9 +179,9 @@ export function next (element : HTMLElement, selector : null|string = null) : nu
  *
  * The nearest sibling is the first element in the list.
  */
-export function prevAll (element : HTMLElement, selector : null|string = null) : HTMLElement[]
+export function prevAll<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string = null) : T[]
 {
-    return fetchAllSiblings(element, selector, "previousElementSibling");
+    return fetchAllSiblings<T>(element, selector, "previousElementSibling");
 }
 
 
@@ -191,9 +191,9 @@ export function prevAll (element : HTMLElement, selector : null|string = null) :
  *
  * The nearest sibling is the first element in the list.
  */
-export function nextAll (element : HTMLElement, selector : null|string = null) : HTMLElement[]
+export function nextAll<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string = null) : T[]
 {
-    return fetchAllSiblings(element, selector, "nextElementSibling");
+    return fetchAllSiblings<T>(element, selector, "nextElementSibling");
 }
 
 
@@ -201,9 +201,9 @@ export function nextAll (element : HTMLElement, selector : null|string = null) :
  * Returns all siblings
  * (optionally matching the given selector)
  */
-export function siblings (element : HTMLElement, selector : null|string = null) : HTMLElement[]
+export function siblings<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : null|string = null) : T[]
 {
-    const list : HTMLElement[] = [];
+    const list : T[] = [];
     let sibling : null|Element = null;
 
     if (null !== element.parentElement)
@@ -215,7 +215,7 @@ export function siblings (element : HTMLElement, selector : null|string = null) 
     {
         if (sibling !== element && elementMatches(sibling, selector))
         {
-            list.push(sibling as HTMLElement);
+            list.push(sibling as T);
         }
 
         sibling = sibling.nextElementSibling;
@@ -230,7 +230,7 @@ export function siblings (element : HTMLElement, selector : null|string = null) 
  *
  * If a root element is given, the parent is only searched up to (and excluding) this root node.
  */
-export function closest (element : HTMLElement, selector : string, rootElement : null|HTMLElement = null) : null|HTMLElement
+export function closest<T extends HTMLElement = HTMLElement> (element : HTMLElement, selector : string, rootElement : null|HTMLElement = null) : null|T
 {
     let parent = element.parentElement;
 
@@ -238,7 +238,7 @@ export function closest (element : HTMLElement, selector : string, rootElement :
     {
         if (parent.matches(selector))
         {
-            return parent;
+            return parent as T;
         }
 
         parent = parent.parentElement;

--- a/dom/traverse.ts
+++ b/dom/traverse.ts
@@ -89,24 +89,24 @@ export function filter<T extends HTMLElement = HTMLElement> (list : HTMLElement[
  * Filters a list of DOM elements that DO NOT match the given selector,
  * are not the given node or are not in the given node list.
  */
-export function not<T extends HTMLElement = HTMLElement> (list : HTMLElement[], selector : string|HTMLElement|HTMLElement[]) : T[]
+export function not<T extends HTMLElement[]> (list : T, selector : string|HTMLElement|HTMLElement[]) : T
 {
     if (typeof selector === "string")
     {
         return list.filter(
             (e) => !e.matches(selector)
-        ) as T[];
+        ) as T;
     }
     else if (Array.isArray(selector))
     {
         return list.filter(
             (e) => -1 !== selector.indexOf(e)
-        ) as T[];
+        ) as T;
     }
 
     return list.filter(
         (e) => e !== selector
-    ) as T[];
+    ) as T;
 }
 
 

--- a/kaba.js
+++ b/kaba.js
@@ -4,6 +4,7 @@ module.exports = (new Kaba())
     .addJavaScriptEntries({
         "all-tests": "tests/build/all-tests.js",
     })
+    .enableTypeScript()
     .setOutputPath("tests/dist")
     .disableChunkSplitting()
     .disableFileNameHashing()

--- a/ui/Sortable.ts
+++ b/ui/Sortable.ts
@@ -27,7 +27,7 @@ export default class Sortable
 
     /**
      */
-    constructor (container : HTMLElement, config : SortableConfig)
+    public constructor (container : HTMLElement, config : SortableConfig)
     {
         this.container = container;
         this.config = merge({
@@ -47,13 +47,13 @@ export default class Sortable
     /**
      * Initializes the component
      */
-    init ()
+    public init (): void
     {
-        delegate(
+        delegate<MouseEvent>(
             this.container,
             `${this.config.items} ${this.config.handle}`,
             "mousedown",
-            (event : Event) => this.onInteractionStart(event as MouseEvent)
+            event => this.onInteractionStart(event)
         );
     }
 

--- a/ui/Sortable/GhostHandler/TrHandler.ts
+++ b/ui/Sortable/GhostHandler/TrHandler.ts
@@ -10,7 +10,7 @@ export default class TrHandler implements GhostHandler
      */
     constructor (tableRow : HTMLTableRowElement)
     {
-        this.cells = find("td", tableRow) as HTMLTableCellElement[];
+        this.cells = find<HTMLTableCellElement>("td", tableRow);
     }
 
 


### PR DESCRIPTION
Most mojave APIs are very generic by-design, which can lead to many situations where you have to cast the return of a mojave method to a more explicit/specific type, which is just unnecessary noise.

```typescript
// before
let divElement = findOne(".my-div", this.container);
let inputElement = findOne(".my-input", this.container) as HTMLInputElement;

// after
let divElement = findOne(".my-div", this.container);
let inputElement = findOne<HTMLInputElement>(".my-input", this.container);
```

I've used the previously hardcoded types as default for the generic type parameters, which makes this change backwards compatible and allows us to omit the type parameters when they match the default.

This is the very first pass of making most methods generic and easier to work with. For `extend`, `merge` and `debounce` I found the following article pretty helpful: https://spin.atomicobject.com/2018/05/14/type-safe-object-merging-2-8/ However, it lacks support for variadic parameters, which we currently need for all methods. So we'll probably have to wait until https://github.com/Microsoft/TypeScript/issues/5453 has been merged.