### PR TITLE
`request()` finalization

### DIFF
--- a/network.ts
+++ b/network.ts
@@ -9,9 +9,12 @@ interface FetchOptions
     json?: null|{[name: string]: any}|Array<any>,
 }
 
+export type RequestFailureReasons = "status" | "invalid_json" | "request_failed";
+
 interface ApiReturnValues<T> {
     response: Response;
     data: T;
+    reason?: RequestFailureReasons;
 }
 
 
@@ -49,15 +52,15 @@ export function request<T extends object = {}> (url: string, options: FetchOptio
                                 {
                                     if (response.status < 200 || response.status >= 500)
                                     {
-                                        return reject({response, data});
+                                        return reject({response, data, reason: "status"});
                                     }
 
                                     resolve({data, response});
                                 },
-                                (error) => reject({error})
+                                (error) => reject({error, reason: "invalid_json"})
                             );
                     },
-                    (error) => reject({error}),
+                    (error) => reject({error, reason: "request_failed"}),
                 );
         }
     );

--- a/network.ts
+++ b/network.ts
@@ -6,7 +6,8 @@ interface FetchOptions
     method?: string;
     headers?: {[name: string]: string};
     data?: BodyInit|null;
-    json?: null|{[name: string]: any}|Array<any>,
+    json?: null|{[name: string]: any}|Array<any>;
+    credentials?: boolean;
 }
 
 export type RequestFailureReasons = "status" | "invalid_json" | "request_failed";
@@ -41,7 +42,7 @@ export function request<T extends object = {}> (url: string, options: FetchOptio
             fetch(url, {
                 body: data,
                 cache: "no-cache",
-                credentials: "include",
+                credentials: false !== options.credentials ? "include" : "omit",
                 headers: headers,
                 method: options.method || "get",
             })

--- a/network.ts
+++ b/network.ts
@@ -10,16 +10,48 @@ export interface RequestOptions
     credentials?: boolean;
 }
 
-export type RequestFailureReasons = "status" | "invalid_json" | "request_failed";
-
+/**
+ * Promise return value if the request succeeded, and the promise resolves.
+ *
+ * The success flag indicates if the request was performed successfully (will be false if the status code was `400`).
+ */
 export interface SuccessResponse<T> {
     response: Response;
+    success: boolean;
     data: T;
 }
 
-export interface FailureResponse {
+
+/**
+ * All promise return values in the rejection cases.
+ */
+export type FailureResponse = RequestFailureResponse | JsonFailureResponse | StatusFailureResponse;
+
+/**
+ * Promise return value if the request failed
+ */
+export interface RequestFailureResponse {
     error: Error;
-    reason: RequestFailureReasons;
+    reason: "request_failed";
+}
+
+/**
+ * Promise return value if the JSON decoding failed
+ */
+export interface JsonFailureResponse {
+    error: Error;
+    response: Response;
+    reason: "invalid_json";
+}
+
+/**
+ * Promise return value if the HTTP status code indicated an (unexpected) error
+ */
+export interface StatusFailureResponse {
+    error: Error;
+    response: Response;
+    data: any;
+    reason: "invalid_json";
 }
 
 
@@ -40,7 +72,6 @@ export function request<T extends object = {}> (url: string, options: RequestOpt
         headers["Content-Type"] = "application/json; charset=UTF-8";
     }
 
-
     return new Promise(
         (resolve, reject) => {
             fetch(url, {
@@ -55,14 +86,16 @@ export function request<T extends object = {}> (url: string, options: RequestOpt
                             .then(
                                 data =>
                                 {
-                                    if (response.status < 200 || response.status >= 500)
+                                    // allow 400, as we pass validation errors as 400 and they should resolve the promise,
+                                    // as they are "expected" errors.
+                                    if ((response.status >= 200 && response.status < 300) || response.status === 400)
                                     {
-                                        return reject({response, data, reason: "status"});
+                                        return resolve({data, response, success: response.status !== 400});
                                     }
 
-                                    resolve({data, response});
+                                    reject({response, data, reason: "status"});
                                 },
-                                (error) => reject({error, reason: "invalid_json"})
+                                (error) => reject({response, error, reason: "invalid_json"})
                             );
                     },
                     (error) => reject({error, reason: "request_failed"}),

--- a/network.ts
+++ b/network.ts
@@ -1,7 +1,7 @@
 import fetch from "./polyfill/fetch";
 import {extend} from "./extend";
 
-interface FetchOptions
+export interface RequestOptions
 {
     method?: string;
     headers?: {[name: string]: string};
@@ -12,17 +12,21 @@ interface FetchOptions
 
 export type RequestFailureReasons = "status" | "invalid_json" | "request_failed";
 
-interface ApiReturnValues<T> {
+export interface SuccessResponse<T> {
     response: Response;
     data: T;
-    reason?: RequestFailureReasons;
+}
+
+export interface FailureResponse {
+    error: Error;
+    reason: RequestFailureReasons;
 }
 
 
 /**
  * Small wrapper to fetch a JSON response
  */
-export function request<T extends object = {}> (url: string, options: FetchOptions = {}) : Promise<ApiReturnValues<T>>
+export function request<T extends object = {}> (url: string, options: RequestOptions = {}) : Promise<SuccessResponse<T>|FailureResponse>
 {
     let headers = extend(options.headers || {}, {
         Accept: "application/json",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     },
     "scripts": {
         "test": "node_modules/.bin/browserstack-runner",
-        "build": "node_modules/.bin/tsc --version && node_modules/.bin/tsc --diagnostics --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty"
+        "build": "node_modules/.bin/tsc --version && node_modules/.bin/tsc --diagnostics --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty",
+        "dev": "node_modules/.bin/tsc --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty -w"
     }
 }


### PR DESCRIPTION
This changes the behavior of `request()`

## Success Case (Promise is _resolved_)

### IF

* JSON is valid AND
* Response status code is 2xx / 400 (400 as we pass validation errors as this value and they are "expected" errors)

### Return Type

```js
{ 
    response: Response,
    success: boolean, // true if status code is 2xx, false if 400
    data: /* payload */,
}
```

## Failure Case: Request (Promise is _rejected_)

### IF

* the request fails

### Return Type

```js
{ 
    error: Error,
    reason: "request_failed",
}
```

## Failure Case: JSON (Promise is _rejected_)

### IF

* the decoding of the JSON response fails

### Return Type

```js
{ 
    response: Response,
    error: Error,
    reason: "invalid_json",
}
```


## Failure Case: Status Code (Promise is _rejected_)

### IF

* the response status code is 1xx / 3xx / 4xx (except 400), 5xx

### Return Type

```js
{ 
    response: Response,
    data: any,
    reason: "status",
}
```