### PR TITLE
Add hydrate mode + smaller bugfixes in mount + tests

### DIFF
--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -48,6 +48,11 @@ declare namespace mojave
          * Additional parameters to pass as props / constructor arguments
          */
         params?: {[k: string]: any};
+
+        /**
+         * Flag whether the element should be hydrated (if possible) or the mounting element should be removed.
+         */
+        hydrate?: boolean;
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 =====
 
 *   Added new function `hasOwnProperty()`.
+*   Added a new `hydrate` option when mounting JSX components. It decides whether 
+    *   `hydrate: false/undefined` -> the body is parsed as JSON (and passed as props) and the mounting node is removed
+    *   `hydrate: true` -> the mounting node is left untouched and preact mounts on this node (if possible). The content is *not* parsed as JSON.
 
 
 4.0.0

--- a/browserstack.json
+++ b/browserstack.json
@@ -8,9 +8,7 @@
         {"browser": "firefox", "browser_version": "latest", "device": null, "os": "Windows", "os_version": "10" },
         {"browser": "edge", "browser_version": "latest", "device": null, "os": "Windows", "os_version": "10" },
         {"browser": "ie", "browser_version": "11.0", "device": null, "os": "Windows", "os_version": "8.1" },
-        {"browser": "chrome", "browser_version": "latest", "device": null, "os": "OS X", "os_version": "High Sierra" },
-        {"browser": "firefox", "browser_version": "latest", "device": null, "os": "OS X", "os_version": "High Sierra" },
-        {"browser": "safari", "browser_version": "latest", "device": null, "os": "OS X", "os_version": "High Sierra" },
+        {"browser": "safari", "browser_version": "latest", "device": null, "os": "OS X", "os_version": "Mojave" },
         {"os": "ios", "browser_version": "latest", "device": "iPhone 8 Plus", "os_version": "11.0", "real_mobile": true},
         {"os": "android", "browser_version": "latest", "device": "Google Pixel", "os_version": "8.0", "real_mobile": true}
     ]

--- a/mount/index.ts
+++ b/mount/index.ts
@@ -58,20 +58,29 @@ function doMount (elements: HTMLElement[], mountable: mojave.Mountable, rawOptio
             {
                 let opts = options as mojave.ComponentMountOptions;
                 let parent = node.parentElement;
+                let params = opts.params || {};
 
-                if (parent === null)
+                if (!parent)
                 {
                     console.error("Can't mount on container without parent.");
                     return;
                 }
 
-                render(
-                    createElement(mountable as ComponentType<any>, extend(opts.params || {}, safeParseJson(node.textContent) || {})),
-                    parent,
-                    node
-                );
+                if (!opts.hydrate)
+                {
+                    // if the node should not be hydrated, try to use the content as JSON
+                    params = extend(params, safeParseJson(node.textContent) || {});
 
-                parent.removeChild(node);
+                    // remove node before mount, so that we can ensure that preact doesn't reuse it.
+                    parent.removeChild(node);
+                }
+
+                // render
+                render(
+                    createElement(mountable as ComponentType<any>, params),
+                    parent,
+                    opts.hydrate ? node : undefined
+                );
             }
             else if ("class" === options.type)
             {

--- a/tests/cases/mount/mount.jsx
+++ b/tests/cases/mount/mount.jsx
@@ -72,14 +72,57 @@ QUnit.test(
             }
         }
 
-        findOne("#qunit-fixture").innerHTML = `<div id="container"></div>`;
-
+        let fixture = findOne("#qunit-fixture");
+        fixture.innerHTML = `<div id="container"></div>`;
         mount("#container", Test, {type: "jsx"});
 
         assert.strictEqual(
             document.getElementById("qunit-fixture").querySelectorAll(".test").length,
             1
         );
+    }
+);
+
+QUnit.test(
+    "with JSX: remove mount node if not hydrating",
+    assert =>
+    {
+        assert.expect(2);
+        let TestComponent = () =>
+        {
+            return <div className="test"/>;
+        };
+
+        let fixture = findOne("#qunit-fixture");
+        fixture.innerHTML = `<div id="container"></div>`;
+        let mountingPoint = fixture.firstElementChild;
+
+        assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
+        mount("#container", TestComponent, {type: "jsx"});
+        assert.strictEqual(mountingPoint.parentElement, null, "Parent isn't set anymore, as the node has been removed from the DOM");
+    }
+);
+
+QUnit.test(
+    "with JSX: hydrate on mount",
+    assert =>
+    {
+        assert.expect(4);
+        let TestComponent = (props) =>
+        {
+            assert.strictEqual(props.a, undefined, "The JSON in the body has not been parsed.");
+            return <div className="test"/>;
+        };
+
+        let fixture = findOne("#qunit-fixture");
+        fixture.innerHTML = `<div id="container">{"a": 1}</div>`;
+        let mountingPoint = fixture.firstElementChild;
+
+        assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
+        mount("#container", TestComponent, {type: "jsx", hydrate: true});
+        // keep element in DOM
+        assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set after, as the node hasn't been removed from the dom.");
+        assert.strictEqual(fixture.childElementCount, 1, "The node was hydrated / reused and no new node was added.");
     }
 );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->

* Added a new `hydrate` option for JSX mounts.
* Fixed an implementation, where the mounted element might have been directly removed.
* Also fixed the tests