### PR TITLE
Add `getScrollParent()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 *   Add `parseElementAsJson()` that automatically parses JSON from the content of a node and removes HTML escaping.
+*   Add `getScrollParent()`, that fetches a scrollable parent of an element.
 
 
 4.1.0

--- a/scroll.ts
+++ b/scroll.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns the scroll parent of the given node.
+ *
+ * If this returns null, the scroll parent is document.documentElement
+ */
+export function getScrollParent (node: Node|null) : Element|null
+{
+    if (!node || !(node instanceof Element))
+    {
+        return null;
+    }
+
+    const overflowY = window.getComputedStyle(node).overflowY || "";
+    // is scrollable if value is neither visible nor hidden
+    const isScrollable = (overflowY.indexOf('visible') + overflowY.indexOf('hidden')) === -2;
+
+    if (isScrollable && node.scrollHeight >= node.clientHeight)
+    {
+        return node;
+    }
+
+    return getScrollParent(node.parentNode);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
Adds `getScrollParent()` that returns a scrollable parent.