### PR TITLE
Add `onNextAnimationFrame()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 *   Add `parseElementAsJson()` that automatically parses JSON from the content of a node and removes HTML escaping.
 *   Add `getScrollParent()`, that fetches a scrollable parent of an element.
+*   Add `onNextAnimationFrame()`.
 
 
 4.1.0

--- a/timing.ts
+++ b/timing.ts
@@ -18,3 +18,31 @@ export function debounce (func : (...args : any[]) => void, delay : number = 80)
         timeoutId = window.setTimeout(later, delay);
     };
 }
+
+
+/**
+ * Returns a callback. If this returned value is called, it will call the given run callback in the
+ * next animation frame. Duplicate calls in the same frame will be dropped.
+ *
+ * Example usage is handling scroll events without thrashing the main thread, but acting
+ * on every scroll paint update:
+ *
+ *      on(window, "scroll", onNextAnimationFrame(() => doSth(1, 2, 3));
+ *
+ * The arguments will be passed to the given callback.
+ */
+export function onNextAnimationFrame (run: (...args: any[]) => void) : (...args: any[]) => void
+{
+    let token: number|null = null;
+
+    return (...args) =>
+    {
+        if (!token)
+        {
+            token = window.requestAnimationFrame(() => {
+                run(...args);
+                token = null;
+            });
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
A convenience wrapper for wrapping `requestAnimationFrame()`.