### PR TITLE
Allow functional components to receive additional parameters

### DIFF
--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -8,7 +8,7 @@ declare namespace mojave
         }
     };
     export type MountableType = "func" | "jsx" | "class";
-    export type MountableFunction = (element: HTMLElement) => void;
+    export type MountableFunction = (element: HTMLElement, ...args: any[]) => void;
     export type Mountable = MountableFunction|MountableClass|ComponentFactory<any>;
 
 

--- a/tests/cases/mount/mount.jsx
+++ b/tests/cases/mount/mount.jsx
@@ -173,22 +173,24 @@ QUnit.test(
     "with function: correct argument passing",
     assert =>
     {
-        assert.expect(3);
+        assert.expect(4);
 
         findOne("#qunit-fixture").innerHTML = `<div id="container"></div>`;
         let fixtures = document.getElementById("qunit-fixture");
         let container = fixtures.firstElementChild;
+        let objectParam = {a: "a"};
 
         mount(
             "#container",
-            (element, a, b) => {
+            (element, a, b, c) => {
                 assert.strictEqual(element, container);
                 assert.strictEqual(a, 1);
                 assert.strictEqual(b, 2);
+                assert.strictEqual(c, objectParam);
             },
             {
                 context: fixtures,
-                params: [1, 2]
+                params: [1, 2, objectParam]
             }
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| Improvement?  | yes<!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | **missing** <!-- insert URL here -->

Currently TypeScript wasn't happy about functional components to receive more than one argument. In fact, we haven't had this test case covered. This PR let's TypeScript know that there may be more than one parameter for functional components. I've also added a test case for exactly this case.