### PR TITLE
Filter out null elements from array of elements passed into `on` and `off`

### DIFF
--- a/dom/events.ts
+++ b/dom/events.ts
@@ -29,11 +29,6 @@ type GenericEventListener<T extends Event = Event> = {
  */
 export function on<T extends Event = Event> (element : null|EventTarget|EventTarget[], type : string|string[], handler : GenericEventListener<T>) : void
 {
-    if (null === element)
-    {
-        return;
-    }
-
     const list = (Array.isArray(element) ? element : [element]);
     const types = splitStringValue(type);
 
@@ -75,11 +70,6 @@ export function on<T extends Event = Event> (element : null|EventTarget|EventTar
  */
 export function off<T extends Event = Event> (element : null|EventTarget|EventTarget[], type : string|string[], handler : GenericEventListener<T>) : void
 {
-    if (null === element)
-    {
-        return;
-    }
-
     const list = (Array.isArray(element) ? element : [element]);
     const types = splitStringValue(type);
 

--- a/dom/events.ts
+++ b/dom/events.ts
@@ -23,11 +23,13 @@ type GenericEventListener<T extends Event = Event> = {
     (event: T): void;
 }
 
+type EventHandlerTargets = null | EventTarget | (null|EventTarget)[];
+
 
 /**
  * Registers an event listener for the given events
  */
-export function on<T extends Event = Event> (element : null|EventTarget|EventTarget[], type : string|string[], handler : GenericEventListener<T>) : void
+export function on<T extends Event = Event> (element : EventHandlerTargets, type : string|string[], handler : GenericEventListener<T>) : void
 {
     const list = (Array.isArray(element) ? element : [element]);
     const types = splitStringValue(type);
@@ -68,7 +70,7 @@ export function on<T extends Event = Event> (element : null|EventTarget|EventTar
 /**
  * Removes an event listener for the given events
  */
-export function off<T extends Event = Event> (element : null|EventTarget|EventTarget[], type : string|string[], handler : GenericEventListener<T>) : void
+export function off<T extends Event = Event> (element : EventHandlerTargets, type : string|string[], handler : GenericEventListener<T>) : void
 {
     const list = (Array.isArray(element) ? element : [element]);
     const types = splitStringValue(type);

--- a/dom/events.ts
+++ b/dom/events.ts
@@ -42,6 +42,12 @@ export function on<T extends Event = Event> (element : null|EventTarget|EventTar
         for (let j = 0; j < types.length; j++)
         {
             const node = list[i];
+
+            if (null === node)
+            {
+                continue;
+            }
+
             const eventType = types[j];
 
             node.addEventListener(eventType, handler as EventListener);
@@ -82,6 +88,12 @@ export function off<T extends Event = Event> (element : null|EventTarget|EventTa
         for (let j = 0; j < types.length; j++)
         {
             const node = list[i];
+
+            if (null === node)
+            {
+                continue;
+            }
+
             const eventType = types[j];
 
             node.removeEventListener(eventType, handler as EventListener);

--- a/tests/cases/dom/events/off.js
+++ b/tests/cases/dom/events/off.js
@@ -76,12 +76,10 @@ QUnit.test(
     "off() with an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                off(findOne(".example"), null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        off(findOne(".example"), "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -89,12 +87,10 @@ QUnit.test(
     "off() with an array of elements and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                off([findOne(".example")], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        off([findOne(".example")], "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -102,12 +98,10 @@ QUnit.test(
     "off() with an array of null and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                off([null, null, null], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        off([null, null, null], "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -115,11 +109,9 @@ QUnit.test(
     "off() with an array of mixed entries (null and existing element) and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                off([null, findOne(".example"), null], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        off([null, findOne(".example"), null], "", () => {});
+        assert.ok(true);
     }
 );

--- a/tests/cases/dom/events/off.js
+++ b/tests/cases/dom/events/off.js
@@ -50,12 +50,74 @@ QUnit.test(
 
 
 QUnit.test(
+    "off() with array of null",
+    (assert) =>
+    {
+        assert.expect(1);
+
+        off([null, null, null], "click", () => {});
+        assert.ok(true);
+    }
+);
+
+QUnit.test(
+    "off() with array of mixed entries (null and existing element)",
+    (assert) =>
+    {
+        assert.expect(1);
+
+        off([null, findOne(".example"), null], "click", () => {});
+        assert.ok(true);
+    }
+);
+
+
+QUnit.test(
     "off() with an invalid event",
     (assert) =>
     {
         assert.throws(
             () => {
                 off(findOne(".example"), null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "off() with an array of elements and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                off([findOne(".example")], null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "off() with an array of null and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                off([null, null, null], null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "off() with an array of mixed entries (null and existing element) and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                off([null, findOne(".example"), null], null, () => {});
             },
             "function threw an error"
         );

--- a/tests/cases/dom/events/on.js
+++ b/tests/cases/dom/events/on.js
@@ -149,12 +149,10 @@ QUnit.test(
     "on() with an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                on(findOne(".example"), null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        on(findOne(".example"), "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -162,12 +160,10 @@ QUnit.test(
     "on() with an array of elements and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                on([findOne(".example")], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        on([findOne(".example")], "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -175,12 +171,10 @@ QUnit.test(
     "on() with an array of null and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                on([null, null, null], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        on([null, null, null], "", () => {});
+        assert.ok(true);
     }
 );
 
@@ -188,11 +182,9 @@ QUnit.test(
     "on() with an array of mixed entries (null and existing element) and an invalid event",
     (assert) =>
     {
-        assert.throws(
-            () => {
-                on([null, findOne(".example"), null], null, () => {});
-            },
-            "function threw an error"
-        );
+        assert.expect(1);
+
+        on([null, findOne(".example"), null], "", () => {});
+        assert.ok(true);
     }
 );

--- a/tests/cases/dom/events/on.js
+++ b/tests/cases/dom/events/on.js
@@ -123,12 +123,74 @@ QUnit.test(
 
 
 QUnit.test(
+    "on() with array of null",
+    (assert) =>
+    {
+        assert.expect(1);
+
+        on([null, null, null], "click", () => {});
+        assert.ok(true);
+    }
+);
+
+QUnit.test(
+    "on() with array of mixed entries (null and existing element)",
+    (assert) =>
+    {
+        assert.expect(1);
+
+        on([null, findOne(".example"), null], "click", () => {});
+        assert.ok(true);
+    }
+);
+
+
+QUnit.test(
     "on() with an invalid event",
     (assert) =>
     {
         assert.throws(
             () => {
                 on(findOne(".example"), null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "on() with an array of elements and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                on([findOne(".example")], null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "on() with an array of null and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                on([null, null, null], null, () => {});
+            },
+            "function threw an error"
+        );
+    }
+);
+
+QUnit.test(
+    "on() with an array of mixed entries (null and existing element) and an invalid event",
+    (assert) =>
+    {
+        assert.throws(
+            () => {
+                on([null, findOne(".example"), null], null, () => {});
             },
             "function threw an error"
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| Improvement?  | yes<!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | **missing** <!-- insert URL here -->

Right now it's not possible to pass in an array of elements that contain `null` to `on` and `off`. This PR filters these elements out and adds various more tests to cover these cases