### PR TITLE
[v4] Replace promiscuous with promise-polyfill for better support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "mitt": "^1.1.3",
         "preact": "^10.0.0-beta.2",
-        "promiscuous": "^0.7.2",
+        "promise-polyfill": "8.1.3",
         "unfetch": "^4.1.0"
     },
     "devDependencies": {

--- a/polyfill/promise.ts
+++ b/polyfill/promise.ts
@@ -1,5 +1,5 @@
 //@ts-ignore
-import Promise from "promiscuous";
+import Promise from "promise-polyfill";
 
 let globalWindow = window as any;
 

--- a/polyfill/promise.ts
+++ b/polyfill/promise.ts
@@ -1,9 +1,1 @@
-//@ts-ignore
-import Promise from "promise-polyfill";
-
-let globalWindow = window as any;
-
-if (globalWindow.Promise === undefined)
-{
-    globalWindow.Promise = Promise;
-}
+import "promise-polyfill/src/polyfill";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->
| Improvement?  | yes<!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | none

Apparently `promiscuous` doesn't support `Promise.finally`, which the new polyfill does. We could argue whether we should see this PR as a bug fix or a simply a feature PR. Technically it's a new feature. However, that `Promise.finally` was even missing might be considered a bug/oversight.
