### PR TITLE
[v5] Mount improvements: automatic parameter inference/checking

### DIFF
--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -1,4 +1,4 @@
-import {ComponentClass, ComponentFactory, FunctionComponent, VNode} from "preact";
+import {ComponentClass, FunctionComponent, VNode} from "preact";
 import {Tuple} from "ts-toolbelt";
 
 declare namespace mojave
@@ -8,9 +8,7 @@ declare namespace mojave
             init(): void;
         }
     };
-    export type MountableType = "func" | "jsx" | "class";
     export type MountableFunction = (element: HTMLElement, ...args: any[]) => any;
-    export type Mountable = MountableFunction|MountableClass|ComponentFactory<any>;
 
 
     export interface MountOptions
@@ -23,8 +21,6 @@ declare namespace mojave
 
     export interface ClassMountOptions<T extends mojave.MountableClass> extends MountOptions
     {
-        type: "class";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */
@@ -33,8 +29,6 @@ declare namespace mojave
 
     export interface FunctionMountOptions<T extends mojave.MountableFunction> extends MountOptions
     {
-        type?: "func";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */
@@ -43,8 +37,6 @@ declare namespace mojave
 
     export interface ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>> extends MountOptions
     {
-        type: "jsx";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */

--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -1,4 +1,5 @@
-import {ComponentFactory} from "preact";
+import {ComponentClass, ComponentFactory, FunctionComponent, VNode} from "preact";
+import {Tuple} from "ts-toolbelt";
 
 declare namespace mojave
 {
@@ -8,7 +9,7 @@ declare namespace mojave
         }
     };
     export type MountableType = "func" | "jsx" | "class";
-    export type MountableFunction = (element: HTMLElement, ...args: any[]) => void;
+    export type MountableFunction = (element: HTMLElement, ...args: any[]) => any;
     export type Mountable = MountableFunction|MountableClass|ComponentFactory<any>;
 
 
@@ -20,34 +21,38 @@ declare namespace mojave
         context?: Document|HTMLElement;
     }
 
-    export interface ClassMountOptions extends MountOptions
+    export interface ClassMountOptions<T extends mojave.MountableClass> extends MountOptions
     {
         type: "class";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: any[];
+        params?: Tuple.Drop<ConstructorParameters<T>, "1", "->">;
     }
 
-    export interface FunctionMountOptions extends MountOptions
+    export interface FunctionMountOptions<T extends mojave.MountableFunction> extends MountOptions
     {
         type?: "func";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: any[];
+        params?: Tuple.Drop<Parameters<T>, "1", "->">;
     }
 
-    export interface ComponentMountOptions extends MountOptions
+    export interface ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>> extends MountOptions
     {
         type: "jsx";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: {[k: string]: any};
+        params?: T extends ComponentClass<infer TClassProps>
+            ? TClassProps
+            : T extends (props: infer TFunctionProps, context?: any) => VNode<any> | null
+                ? TFunctionProps
+                : never;
 
         /**
          * Flag whether the element should be hydrated (if possible) or the mounting element should be removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+5.0.0
+=====
+
+* Split `mount` into three methods:
+    * `mount` for mounting functions
+    * `mountClass` for mounting `StandaloneComponent`s
+    * `mountJsx` for mounting Preact components (functional and class)
+* `mojave.MountOptions`'s specific implementations have been updated to add support for automatic parameter inference:
+    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
+    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
+    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+
+
 4.5.2
 =====
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,17 @@
+4.x to 5.0
+==========
+
+* `mount` has been split into three methods:
+    * `mount` for mounting functions
+    * `mountClass` for mounting `StandaloneComponent`s
+    * `mountJsx` for mounting Preact components (functional and class)
+* Corresponding to the changes in `mount`, we had to change the mounting option types to add support for automatic parameter inference:
+    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
+    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
+    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+
+
+
 3.x to 4.0
 ==========
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "mitt": "^1.1.3",
-        "preact": "^10.0.0-rc.0",
+        "preact": "^10.0.0-rc.1",
         "promise-polyfill": "^8.1.3",
         "unfetch": "^4.1.0"
     },
@@ -32,6 +32,7 @@
         "kaba": "^8.1.0",
         "qunit": "^2.9.2",
         "travis-size-report": "^1.1.0",
+        "ts-toolbelt": "^3.2.14",
         "typescript": "^3.5.3"
     },
     "keywords": [

--- a/tests/cases/mount/mount.jsx
+++ b/tests/cases/mount/mount.jsx
@@ -1,6 +1,6 @@
 import {findOne} from "../../../dom/traverse";
 import QUnit from "qunit";
-import {mount} from "../../../mount";
+import {mount, mountClass, mountJsx} from "../../../mount";
 import {h} from "preact";
 
 
@@ -53,7 +53,7 @@ QUnit.test(
             init () {}
         }
 
-        mount(".fixture", ExampleMountComponent, {params: [42], context, type: "class"});
+        mountClass(".fixture", ExampleMountComponent, {params: [42], context});
     }
 );
 
@@ -71,7 +71,7 @@ QUnit.test(
 
         let fixture = findOne("#qunit-fixture");
         fixture.innerHTML = `<div id="container"></div>`;
-        mount("#container", TestComponent, {type: "jsx"});
+        mountJsx("#container", TestComponent);
 
         assert.strictEqual(
             document.getElementById("qunit-fixture").querySelectorAll(".test").length,
@@ -95,7 +95,7 @@ QUnit.test(
         let mountingPoint = fixture.firstElementChild;
 
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
-        mount("#container", TestComponent, {type: "jsx"});
+        mountJsx("#container", TestComponent);
         assert.strictEqual(mountingPoint.parentElement, null, "Parent isn't set anymore, as the node has been removed from the DOM");
     }
 );
@@ -116,7 +116,7 @@ QUnit.test(
         let mountingPoint = fixture.firstElementChild;
 
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
-        mount("#container", TestComponent, {type: "jsx", hydrate: true});
+        mountJsx("#container", TestComponent, {hydrate: true});
         // keep element in DOM
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set after, as the node hasn't been removed from the dom.");
         assert.strictEqual(fixture.childElementCount, 1, "The node was hydrated / reused and no new node was added.");
@@ -143,7 +143,7 @@ QUnit.test(
         };
 
         findOne("#qunit-fixture").innerHTML = `<div id="container"></div>`;
-        mount("#container", TestComponent, {type: "jsx", params});
+        mountJsx("#container", TestComponent, {params});
     }
 );
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |


This PR splits the `mount` method up (again) into three distinct methods:
- `mount` for mounting `function`s
- `mountClass` for mounting `StandaloneComponent`s
- `mountJsx` for mounting Preact components (functional and class)

This change has sadly been necessary, as TypeScripts generic type inference couldn't support a new feature: automatic parameter inference/checking for the component you were trying to mount. In case there is no additional component parameters, the corresponding `mojave.*MountOptions::params` type will be `never`, to enforce this as well.

There is one caveat to this feature, which I'm not yet sure how to prevent/implement it right now, which is TypeScript isn't throwing any errors when I don't define the `options.params` property. However, this is a known limitation (for now) which I greatly accept as the new feature is better for overall DX and reduces the amount of accidental errors. Other than that, we're currently not throwing any errors as well, so this is not even a regression and thus should be fine.

Here are a few examples of what's working and what is (currently) still not yet possible to support:


## `mount` with `function`s

Example component

```typescript
function someMountableFunction(el: HTMLElement, a: boolean): void
{
}
```

`mount` now is aware of the second, boolean parameter and correctly throws errors when too few or too many parameters have been passed. It extracts any additional `function` from the passed-in function and uses these as type for `mojave.FunctionMountOptions::params`:

```typescript
mount(".foo", someMountableFunction);                           // no errors -> false positive & known limitation!
mount(".foo", someMountableFunction, { type: "func" });         // no errors -> false positive & known limitation!
mount(".foo", someMountableFunction, { type: "func", params: [  // no errors -> correct!
    true,
]});
mount(".foo", someMountableFunction, { type: "func", params: [  // errors, too many parameters -> correct!
    true,
    "bla", // unknown additional parameter
    42,    // unknown additional parameter
]});
```


## `mountClass` with `StandaloneComponent`

Example component

```typescript
class SomeMountableComponent extends StandaloneComponent
{
    private el: HTMLElement;
    private a: boolean;

    public constructor(el: HTMLElement, a: boolean)
	{
        this.el = el;
        this.a = a;
    }

    /**
     * @inheritDoc
     */
    public init(): void
    {
    }
}
```

Here, mounting `SomeMountableComponent` using `mountClass` works the same way as `mount` does: It automatically extracts additional constructor parameters from the passed-in `StandaloneComponent`, which is then used as type for `mojave.ClassMountOptions::params` to check against.

```typescript
mountClass(".foo", SomeMountableComponent);                             // no errors -> false positive & known limitation!
mountClass(".foo", SomeMountableComponent, { type: "class" });          // no errors -> false positive & known limitation!
mountClass(".foo", SomeMountableComponent, { type: "class", params: [   // no errors -> correct!
    true,
]});
mountClass(".foo", SomeMountableComponent, { type: "class", params: [   // errors, too many parameters -> correct!
    true,
    "bla", // unknown additional parameter
    42,    // unknown additional parameter
]});
```


## `mountJsx` with Preact components

Last but not least:

```typescript
//
// Functional component
//
type PreactFunctionalProps = {
    a: string;
    b: number;
}

function SomePreactFunctionalComponent (props: PreactFunctionalProps) : JSX.Element
{
    return null;
}

//
// Class component
//
type SomePreactClassComponentProps = {
    a: string;
    b: number;
}

class SomePreactClassComponent extends Component<SomePreactClassComponentProps, {}>
{
    /**
     * @inheritDoc
     */
    public render(props: Readonly<SomePreactClassComponentProps>, state: Readonly<{}>): preact.ComponentChild
    {
        return null;
    }
}
```

The story here is very similar. The only difference, as previously, is that `mojave.ComponentMountOptions::params`'s type is now the corresponding props-type of the given component. So in the case of `SomePreactFunctionalComponent` the type is `PreactFunctionalProps`, for `SomePreactClassComponent` it's `SomePreactClassComponentProps`.

```typescript
//
// Functional component
//
mountJsx(".foo", SomePreactFunctionalComponent);                            // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactFunctionalComponent, { type: "jsx" });           // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactFunctionalComponent, { type: "jsx", params: {    // no errors -> correct!
    a: "foo",
    b: 42,
}});
mountJsx(".foo", SomePreactFunctionalComponent, { type: "jsx", params: {    // errors, too many parameters -> correct!
    a: "foo",
    b: 42,
    asdf: "bla", // unknown additional parameter
}});

//
// Class component
//
mountJsx(".foo", SomePreactClassComponent);                                 // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactClassComponent, { type: "jsx" });                // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactClassComponent, { type: "jsx", params: {         // no errors -> correct!
    a: "foo",
    b: 42,
}});
mountJsx(".foo", SomePreactClassComponent, { type: "jsx", params: {         // errors, too many parameters -> correct!
    a: "foo",
    b: 42,
    asdf: "bla", // unknown additional parameter
}});
```