### PR TITLE
Mount improvements

### DIFF
--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -1,4 +1,4 @@
-import {ComponentClass, ComponentFactory, FunctionComponent, VNode} from "preact";
+import {ComponentClass, FunctionComponent, VNode} from "preact";
 import {Tuple} from "ts-toolbelt";
 
 declare namespace mojave
@@ -8,9 +8,7 @@ declare namespace mojave
             init(): void;
         }
     };
-    export type MountableType = "func" | "jsx" | "class";
     export type MountableFunction = (element: HTMLElement, ...args: any[]) => any;
-    export type Mountable = MountableFunction|MountableClass|ComponentFactory<any>;
 
 
     export interface MountOptions
@@ -23,8 +21,6 @@ declare namespace mojave
 
     export interface ClassMountOptions<T extends mojave.MountableClass> extends MountOptions
     {
-        type: "class";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */
@@ -33,8 +29,6 @@ declare namespace mojave
 
     export interface FunctionMountOptions<T extends mojave.MountableFunction> extends MountOptions
     {
-        type?: "func";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */
@@ -43,8 +37,6 @@ declare namespace mojave
 
     export interface ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>> extends MountOptions
     {
-        type: "jsx";
-
         /**
          * Additional parameters to pass as props / constructor arguments
          */

--- a/@types/mojave.d.ts
+++ b/@types/mojave.d.ts
@@ -1,4 +1,5 @@
-import {ComponentFactory} from "preact";
+import {ComponentClass, ComponentFactory, FunctionComponent, VNode} from "preact";
+import {Tuple} from "ts-toolbelt";
 
 declare namespace mojave
 {
@@ -8,7 +9,7 @@ declare namespace mojave
         }
     };
     export type MountableType = "func" | "jsx" | "class";
-    export type MountableFunction = (element: HTMLElement, ...args: any[]) => void;
+    export type MountableFunction = (element: HTMLElement, ...args: any[]) => any;
     export type Mountable = MountableFunction|MountableClass|ComponentFactory<any>;
 
 
@@ -20,34 +21,38 @@ declare namespace mojave
         context?: Document|HTMLElement;
     }
 
-    export interface ClassMountOptions extends MountOptions
+    export interface ClassMountOptions<T extends mojave.MountableClass> extends MountOptions
     {
         type: "class";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: any[];
+        params?: Tuple.Drop<ConstructorParameters<T>, "1", "->">;
     }
 
-    export interface FunctionMountOptions extends MountOptions
+    export interface FunctionMountOptions<T extends mojave.MountableFunction> extends MountOptions
     {
         type?: "func";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: any[];
+        params?: Tuple.Drop<Parameters<T>, "1", "->">;
     }
 
-    export interface ComponentMountOptions extends MountOptions
+    export interface ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>> extends MountOptions
     {
         type: "jsx";
 
         /**
          * Additional parameters to pass as props / constructor arguments
          */
-        params?: {[k: string]: any};
+        params?: T extends ComponentClass<infer TClassProps>
+            ? TClassProps
+            : T extends (props: infer TFunctionProps, context?: any) => VNode<any> | null
+                ? TFunctionProps
+                : never;
 
         /**
          * Flag whether the element should be hydrated (if possible) or the mounting element should be removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+5.0.0
+=====
+
+* Split `mount` into three methods:
+    * `mount` for mounting functions
+    * `mountClass` for mounting `StandaloneComponent`s
+    * `mountJsx` for mounting Preact components (functional and class)
+* `mojave.MountOptions`'s specific implementations have been updated to add support for automatic parameter inference:
+    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
+    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
+    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+
+
 4.5.2
 =====
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 =====
 
 * Split `mount` into three methods:
-    * `mount` for mounting functions
+    * `mount` for mounting `function`s
     * `mountClass` for mounting `StandaloneComponent`s
     * `mountJsx` for mounting Preact components (functional and class)
+* Split `mountLazy` into three methods:
+    * `mountLazy` for mounting `function`s
+    * `mountLazyClass` for mounting `StandaloneComponent`s
+    * `mountLazyJsx` for mounting Preact components (functional and class)
+* Removed `{ type: "func"|"class"|"jsx" }` property from derived `mojave.MountOptions`s.
 * `mojave.MountOptions`'s specific implementations have been updated to add support for automatic parameter inference:
-    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
-    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
-    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<TClass extends mojave.MountableClass>`
+    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<TFunction extends mojave.MountableFunction>`
+    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<TComponent extends ComponentClass<any> | FunctionComponent<any>>`
 
 
 4.5.2

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,17 @@
+4.x to 5.0
+==========
+
+* `mount` has been split into three methods:
+    * `mount` for mounting functions
+    * `mountClass` for mounting `StandaloneComponent`s
+    * `mountJsx` for mounting Preact components (functional and class)
+* Corresponding to the changes in `mount`, we had to change the mounting option types to add support for automatic parameter inference:
+    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
+    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
+    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+
+
+
 3.x to 4.0
 ==========
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,14 +1,150 @@
 4.x to 5.0
 ==========
 
-* `mount` has been split into three methods:
-    * `mount` for mounting functions
-    * `mountClass` for mounting `StandaloneComponent`s
-    * `mountJsx` for mounting Preact components (functional and class)
-* Corresponding to the changes in `mount`, we had to change the mounting option types to add support for automatic parameter inference:
-    * `mojave.ClassMountOptions` has been made generic: `mojave.ClassMountOptions<T extends mojave.MountableClass>`
-    * `mojave.FunctionMountOptions` has been made generic: `mojave.FunctionMountOptions<T extends mojave.MountableFunction>`
-    * `mojave.ComponentMountOptions` has been made generic: `mojave.ComponentMountOptions<T extends ComponentClass<any> | FunctionComponent<any>>`
+
+## `mount` and `mountLazy`
+
+### Mounting `function`s
+
+There were two notable changes to the way a `function` will be mounted:
+- the `{type: "func"}` property has been removed from the `mojave.FunctionMountOptions`
+- `mountLazy` now requires to pass in a generic type parameter of your `function` that you want to mount in order
+  to get support for `mojave.FunctionMountOptions::params` to be of the required `function` parameters.
+
+Old:
+
+```typescript
+import {mount, mountLazy} from "mojave/mount";
+import {myFunction} from "./my-function";
+
+// Eager
+mount(".selector", myFunction);
+mount(".selector", myFunction, { type: "func" });
+mount(".selector", myFunction, { type: "func", params: ["…"]});
+mount(".selector", myFunction, { params: ["…"]});
+
+// Lazy
+mountLazy(".selector", () => import("./my-function"));
+mountLazy(".selector", () => import("./my-function"), { type: "func" });
+mountLazy(".selector", () => import("./my-function"), { type: "func", params: ["…"]});
+mountLazy(".selector", () => import("./my-function"), { params: ["…"]});
+```
+
+New:
+
+```typescript
+import {mount, mountLazy} from "mojave/mount";
+import {myFunction} from "./my-function";
+
+// Eager
+mount(".selector", myFunction);
+mount(".selector", myFunction, { params: ["…"]});
+
+// Lazy
+mountLazy<typeof myFunction>(".selector", () => import("./my-function"));
+mountLazy<typeof myFunction>(".selector", () => import("./my-function"), { params: ["…"]});
+```
+
+
+### Mounting `StandaloneComponent`s
+
+There were two notable changes to the way a `StandaloneComponent` will be mounted:
+- the `{type: "class"}` property has been removed from the `mojave.ClassMountOptions`
+- `mountLazyClass` now requires to pass in a generic type parameter of your `StandaloneComponent` that you want to mount in order
+  to get support for `mojave.ClassMountOptions::params` to be of the required `StandaloneComponent` constructor parameters.
+
+Old:
+
+```typescript
+import {mount, mountLazy} from "mojave/mount";
+import {MyStandaloneComponent} from "./MyStandaloneComponent";
+
+// Eager
+mount(".selector", MyStandaloneComponent);
+mount(".selector", MyStandaloneComponent, { type: "class" });
+mount(".selector", MyStandaloneComponent, { type: "class", params: ["…"]});
+mount(".selector", MyStandaloneComponent, { params: ["…"]});
+
+// Lazy
+mountLazy(".selector", () => import("./MyStandaloneComponent"));
+mountLazy(".selector", () => import("./MyStandaloneComponent"), { type: "class" });
+mountLazy(".selector", () => import("./MyStandaloneComponent"), { type: "class", params: ["…"]});
+mountLazy(".selector", () => import("./MyStandaloneComponent"), { params: ["…"]});
+```
+
+New:
+
+```typescript
+import {mountClass, mountLazyClass} from "mojave/mount";
+import {MyStandaloneComponent} from "./MyStandaloneComponent";
+
+// Eager
+mountClass(".selector", MyStandaloneComponent);
+mountClass(".selector", MyStandaloneComponent, { params: ["…"]});
+
+// Lazy
+mountLazyClass<MyStandaloneComponent>(".selector", () => import("./MyStandaloneComponent"));
+mountLazyClass<MyStandaloneComponent>(".selector", () => import("./MyStandaloneComponent"), { params: ["…"]});
+```
+
+
+### Mounting Preact components (functional and class)
+
+There were two notable changes to the way a Preact `function` or `Component<TProps, TState>` component will be mounted:
+- the `{type: "jsx"}` property has been removed from the `mojave.ComponentMountOptions`
+- `mountLazyJsx` now requires to pass in a generic type parameter of your Preact component that you want to mount in order
+  to get support for `mojave.ComponentMountOptions::params` to be of the required `StandaloneComponent` constructor parameters.
+  
+Please note that `mojave.ComponentMountOptions::params` is either a `Tuple` or an `Object`, depending on the Preact component that you want to mount.
+For `function`s the type will be `Tuple`, for `Component<TProps, TState>` it'll be `TProps`.
+
+Old:
+
+```typescript
+import {mount, mountLazy} from "mojave/mount";
+import {MyPreactComponent} from "./MyPreactComponent";
+import {MyPreactFunction} from "./MyPreactFunction";
+
+// Eager
+mount(".selector", MyPreactFunction);
+mount(".selector", MyPreactFunction, { type: "jsx" });
+mount(".selector", MyPreactFunction, { type: "jsx", params: {"…": "…"}});
+mount(".selector", MyPreactFunction, { params: {"…": "…"}});
+mount(".selector", MyPreactComponent);
+mount(".selector", MyPreactComponent, { type: "jsx" });
+mount(".selector", MyPreactComponent, { type: "jsx", params: {"…": "…"}});
+mount(".selector", MyPreactComponent, { params: {"…": "…"}});
+
+// Lazy
+mountLazy(".selector", () => import("./MyPreactFunction"));
+mountLazy(".selector", () => import("./MyPreactFunction"), { type: "jsx" });
+mountLazy(".selector", () => import("./MyPreactFunction"), { type: "jsx", params: {"…": "…"}});
+mountLazy(".selector", () => import("./MyPreactFunction"), { params: {"…": "…"}});
+mountLazy(".selector", () => import("./MyPreactComponent"));
+mountLazy(".selector", () => import("./MyPreactComponent"), { type: "jsx" });
+mountLazy(".selector", () => import("./MyPreactComponent"), { type: "jsx", params: {"…": "…"}});
+mountLazy(".selector", () => import("./MyPreactComponent"), { params: {"…": "…"}});
+```
+
+New:
+
+```typescript
+import {mountJsx, mountLazyJsx} from "mojave/mount";
+import {MyPreactComponent} from "./MyPreactComponent";
+import {MyPreactFunction} from "./MyPreactFunction";
+
+// Eager
+mountJsx(".selector", MyPreactFunction);
+mountJsx(".selector", MyPreactFunction, { params: {"…": "…"}});
+mountJsx(".selector", MyPreactComponent);
+mountJsx(".selector", MyPreactComponent, { params: {"…": "…"}});
+
+// Lazy
+mountLazyJsx<typeof MyPreactFunction>(".selector", () => import("./MyPreactFunction"));
+mountLazyJsx<typeof MyPreactFunction>(".selector", () => import("./MyPreactFunction"), { params: {"…": "…"}});
+mountLazyJsx<MyPreactComponent>(".selector", () => import("./MyPreactComponent"));
+mountLazyJsx<MyPreactComponent>(".selector", () => import("./MyPreactComponent"), { params: {"…": "…"}});
+```
 
 
 

--- a/mount/index.ts
+++ b/mount/index.ts
@@ -20,7 +20,7 @@ export function mountJsx<TPreactComponent extends ComponentFactory<any>>(selecto
  * The importer must import the component.
  * Example:
  *
- *     mountLazy(".selector", () => import("./src/MyComp"));
+ *     mountLazyJsx<MyPreactComp>(".selector", () => import("./src/MyPreactComp"));
  */
 export function mountLazyJsx<TPreactComponent extends ComponentFactory<any>>(selector: string, importer: () => Promise<any>, options?: mojave.ComponentMountOptions<TPreactComponent>) : void
 {
@@ -92,7 +92,7 @@ export function mountClass<TStandaloneComponent extends mojave.MountableClass>(s
  * The importer must import the component.
  * Example:
  *
- *     mountLazy(".selector", () => import("./src/MyComp"));
+ *     mountLazyClass<MyStandaloneComp>(".selector", () => import("./src/MyStandaloneComp"));
  */
 export function mountLazyClass <TStandaloneComponent extends mojave.MountableClass>(selector: string, importer: () => Promise<any>, options?: mojave.ClassMountOptions<TStandaloneComponent>) : void
 {
@@ -142,7 +142,7 @@ export function mount<TFunction extends mojave.MountableFunction>(selector: stri
  * The importer must import the component.
  * Example:
  *
- *     mountLazy(".selector", () => import("./src/MyComp"));
+ *     mountLazy<MyFunctionComp>(".selector", () => import("./src/MyFunctionComp"));
  */
 export function mountLazy <TFunction extends mojave.MountableFunction>(selector: string, importer: () => Promise<any>, options?: mojave.FunctionMountOptions<TFunction>) : void
 {

--- a/mount/index.ts
+++ b/mount/index.ts
@@ -8,9 +8,9 @@ import {parseElementAsJson} from "../json";
 /**
  * Mounts a Preact function or class component into all elements matching the given selector.
  */
-export function mountJsx<T extends ComponentFactory<any>>(selector: string, mountable: T, options?: mojave.ComponentMountOptions<T>): void
+export function mountJsx<TPreactComponent extends ComponentFactory<any>>(selector: string, mountable: TPreactComponent, options?: mojave.ComponentMountOptions<TPreactComponent>): void
 {
-    find(selector).forEach(node => doMountJsx<T>(node, mountable, options));
+    find(selector).forEach(node => doMountJsx<TPreactComponent>(node, mountable, options));
 }
 
 
@@ -22,7 +22,7 @@ export function mountJsx<T extends ComponentFactory<any>>(selector: string, moun
  *
  *     mountLazy(".selector", () => import("./src/MyComp"));
  */
-export function mountLazyJsx<T extends ComponentFactory<any>>(selector: string, importer: () => Promise<any>, options?: mojave.ComponentMountOptions<T>) : void
+export function mountLazyJsx<TPreactComponent extends ComponentFactory<any>>(selector: string, importer: () => Promise<any>, options?: mojave.ComponentMountOptions<TPreactComponent>) : void
 {
     let elements = find(selector);
 
@@ -34,7 +34,7 @@ export function mountLazyJsx<T extends ComponentFactory<any>>(selector: string, 
     importer().then(
         module => {
             elements.forEach(element => {
-                doMountJsx<T>(element, module.default, options);
+                doMountJsx<TPreactComponent>(element, module.default, options);
             });
         },
         error => console.error(`Mounting of component of path '${selector}' failed: ${error.message}`, error)
@@ -45,7 +45,7 @@ export function mountLazyJsx<T extends ComponentFactory<any>>(selector: string, 
 /**
  * Mounts a Preact function or class component
  */
-function doMountJsx<T extends ComponentFactory<any>>(node: HTMLElement, mountable: T, options?: mojave.ComponentMountOptions<T>): void
+function doMountJsx<TPreactComponent extends ComponentFactory<any>>(node: HTMLElement, mountable: TPreactComponent, options?: mojave.ComponentMountOptions<TPreactComponent>): void
 {
     options = options || {};
     let parent = node.parentElement;
@@ -78,10 +78,10 @@ function doMountJsx<T extends ComponentFactory<any>>(node: HTMLElement, mountabl
 /**
  * Mounts a StandaloneComponent into all elements matching the given selector.
  */
-export function mountClass<T extends mojave.MountableClass>(selector: string, mountable: T, options?: mojave.ClassMountOptions<T>): void
+export function mountClass<TStandaloneComponent extends mojave.MountableClass>(selector: string, mountable: TStandaloneComponent, options?: mojave.ClassMountOptions<TStandaloneComponent>): void
 {
     find(selector).forEach(node => {
-        doMountClass<T>(node, mountable, options);
+        doMountClass<TStandaloneComponent>(node, mountable, options);
     });
 }
 
@@ -94,7 +94,7 @@ export function mountClass<T extends mojave.MountableClass>(selector: string, mo
  *
  *     mountLazy(".selector", () => import("./src/MyComp"));
  */
-export function mountLazyClass <T extends mojave.MountableClass>(selector: string, importer: () => Promise<any>, options?: mojave.ClassMountOptions<T>) : void
+export function mountLazyClass <TStandaloneComponent extends mojave.MountableClass>(selector: string, importer: () => Promise<any>, options?: mojave.ClassMountOptions<TStandaloneComponent>) : void
 {
     let elements = find(selector);
 
@@ -106,7 +106,7 @@ export function mountLazyClass <T extends mojave.MountableClass>(selector: strin
     importer().then(
         module => {
             elements.forEach(element => {
-                doMountClass<T>(element, module.default, options);
+                doMountClass<TStandaloneComponent>(element, module.default, options);
             });
         },
         error => console.error(`Mounting of component of path '${selector}' failed: ${error.message}`, error)
@@ -117,7 +117,7 @@ export function mountLazyClass <T extends mojave.MountableClass>(selector: strin
 /**
  * Mounts a StandaloneComponent
  */
-function doMountClass<T extends mojave.MountableClass>(node: HTMLElement, mountable: T, options?: mojave.ClassMountOptions<T>): void
+function doMountClass<TStandaloneComponent extends mojave.MountableClass>(node: HTMLElement, mountable: TStandaloneComponent, options?: mojave.ClassMountOptions<TStandaloneComponent>): void
 {
     options = options || {};
     const mounted = new mountable(node, ...(options.params || []));
@@ -128,10 +128,10 @@ function doMountClass<T extends mojave.MountableClass>(node: HTMLElement, mounta
 /**
  * Mounts a function into all elements matching the given selector.
  */
-export function mount<T extends mojave.MountableFunction>(selector: string, mountable: T, options?: mojave.FunctionMountOptions<T>): void
+export function mount<TFunction extends mojave.MountableFunction>(selector: string, mountable: TFunction, options?: mojave.FunctionMountOptions<TFunction>): void
 {
     find(selector).forEach(node => {
-        doMountFunction<T>(node, mountable, options);
+        doMountFunction<TFunction>(node, mountable, options);
     });
 }
 
@@ -144,7 +144,7 @@ export function mount<T extends mojave.MountableFunction>(selector: string, moun
  *
  *     mountLazy(".selector", () => import("./src/MyComp"));
  */
-export function mountLazy <T extends mojave.MountableFunction>(selector: string, importer: () => Promise<any>, options?: mojave.FunctionMountOptions<T>) : void
+export function mountLazy <TFunction extends mojave.MountableFunction>(selector: string, importer: () => Promise<any>, options?: mojave.FunctionMountOptions<TFunction>) : void
 {
     let elements = find(selector);
 
@@ -156,7 +156,7 @@ export function mountLazy <T extends mojave.MountableFunction>(selector: string,
     importer().then(
         module => {
             elements.forEach(element => {
-                doMountFunction<T>(element, module.default, options);
+                doMountFunction<TFunction>(element, module.default, options);
             });
         },
         error => console.error(`Mounting of component of path '${selector}' failed: ${error.message}`, error)
@@ -167,7 +167,7 @@ export function mountLazy <T extends mojave.MountableFunction>(selector: string,
 /**
  * Mounts a function
  */
-function doMountFunction<T extends mojave.MountableFunction>(node: HTMLElement, mountable: T, options?: mojave.FunctionMountOptions<T>): void
+function doMountFunction<TFunction extends mojave.MountableFunction>(node: HTMLElement, mountable: TFunction, options?: mojave.FunctionMountOptions<TFunction>): void
 {
     options = options || {};
     mountable(node, ...(options.params || []));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "mitt": "^1.1.3",
-        "preact": "^10.0.0-rc.0",
+        "preact": "^10.0.0-rc.1",
         "promise-polyfill": "^8.1.3",
         "unfetch": "^4.1.0"
     },
@@ -32,6 +32,7 @@
         "kaba": "^8.1.0",
         "qunit": "^2.9.2",
         "travis-size-report": "^1.1.0",
+        "ts-toolbelt": "^3.2.14",
         "typescript": "^3.5.3"
     },
     "keywords": [

--- a/tests/cases/mount/mount.jsx
+++ b/tests/cases/mount/mount.jsx
@@ -1,6 +1,6 @@
 import {findOne} from "../../../dom/traverse";
 import QUnit from "qunit";
-import {mount} from "../../../mount";
+import {mount, mountClass, mountJsx} from "../../../mount";
 import {h} from "preact";
 
 
@@ -53,7 +53,7 @@ QUnit.test(
             init () {}
         }
 
-        mount(".fixture", ExampleMountComponent, {params: [42], context, type: "class"});
+        mountClass(".fixture", ExampleMountComponent, {params: [42], context});
     }
 );
 
@@ -71,7 +71,7 @@ QUnit.test(
 
         let fixture = findOne("#qunit-fixture");
         fixture.innerHTML = `<div id="container"></div>`;
-        mount("#container", TestComponent, {type: "jsx"});
+        mountJsx("#container", TestComponent);
 
         assert.strictEqual(
             document.getElementById("qunit-fixture").querySelectorAll(".test").length,
@@ -95,7 +95,7 @@ QUnit.test(
         let mountingPoint = fixture.firstElementChild;
 
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
-        mount("#container", TestComponent, {type: "jsx"});
+        mountJsx("#container", TestComponent);
         assert.strictEqual(mountingPoint.parentElement, null, "Parent isn't set anymore, as the node has been removed from the DOM");
     }
 );
@@ -116,7 +116,7 @@ QUnit.test(
         let mountingPoint = fixture.firstElementChild;
 
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set beforehand");
-        mount("#container", TestComponent, {type: "jsx", hydrate: true});
+        mountJsx("#container", TestComponent, {hydrate: true});
         // keep element in DOM
         assert.strictEqual(mountingPoint.parentElement, fixture, "Parent is set after, as the node hasn't been removed from the dom.");
         assert.strictEqual(fixture.childElementCount, 1, "The node was hydrated / reused and no new node was added.");
@@ -143,7 +143,7 @@ QUnit.test(
         };
 
         findOne("#qunit-fixture").innerHTML = `<div id="container"></div>`;
-        mount("#container", TestComponent, {type: "jsx", params});
+        mountJsx("#container", TestComponent, {params});
     }
 );
 


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |


This PR splits the `mount` method up (again) into three distinct methods:
- `mount` for mounting `function`s
- `mountClass` for mounting `StandaloneComponent`s
- `mountJsx` for mounting Preact components (functional and class)

This change has sadly been necessary, as TypeScripts generic type inference couldn't support a new feature: automatic parameter inference/checking for the component you were trying to mount. In case there is no additional component parameters, the corresponding `mojave.*MountOptions::params` type will be `never`, to enforce this as well.

There is one caveat to this feature, which I'm not yet sure how to prevent/implement it right now, which is TypeScript isn't throwing any errors when I don't define the `options.params` property. However, this is a known limitation (for now) which I greatly accept as the new feature is better for overall DX and reduces the amount of accidental errors. Other than that, we're currently not throwing any errors as well, so this is not even a regression and thus should be fine.

Here are a few examples of what's working and what is (currently) still not yet possible to support:


## `mount` with `function`s

Example component

```typescript
function someMountableFunction(el: HTMLElement, a: boolean): void
{
}
```

`mount` now is aware of the second, boolean parameter and correctly throws errors when too few or too many parameters have been passed. It extracts any additional `function` from the passed-in function and uses these as type for `mojave.FunctionMountOptions::params`:

```typescript
mount(".foo", someMountableFunction);             // no errors -> false positive & known limitation!
mount(".foo", someMountableFunction, { params: [  // no errors -> correct!
    true,
]});
mount(".foo", someMountableFunction, { params: [  // errors, too many parameters -> correct!
    true,
    "bla", // unknown additional parameter
    42,    // unknown additional parameter
]});
```


## `mountClass` with `StandaloneComponent`

Example component

```typescript
class SomeMountableComponent extends StandaloneComponent
{
    private el: HTMLElement;
    private a: boolean;

    public constructor(el: HTMLElement, a: boolean)
	{
        this.el = el;
        this.a = a;
    }

    /**
     * @inheritDoc
     */
    public init(): void
    {
    }
}
```

Here, mounting `SomeMountableComponent` using `mountClass` works the same way as `mount` does: It automatically extracts additional constructor parameters from the passed-in `StandaloneComponent`, which is then used as type for `mojave.ClassMountOptions::params` to check against.

```typescript
mountClass(".foo", SomeMountableComponent);              // no errors -> false positive & known limitation!
mountClass(".foo", SomeMountableComponent, { params: [   // no errors -> correct!
    true,
]});
mountClass(".foo", SomeMountableComponent, { params: [   // errors, too many parameters -> correct!
    true,
    "bla", // unknown additional parameter
    42,    // unknown additional parameter
]});
```


## `mountJsx` with Preact components

Last but not least:

```typescript
//
// Functional component
//
type PreactFunctionalProps = {
    a: string;
    b: number;
}

function SomePreactFunctionalComponent (props: PreactFunctionalProps) : JSX.Element
{
    return null;
}

//
// Class component
//
type SomePreactClassComponentProps = {
    a: string;
    b: number;
}

class SomePreactClassComponent extends Component<SomePreactClassComponentProps, {}>
{
    /**
     * @inheritDoc
     */
    public render(props: Readonly<SomePreactClassComponentProps>, state: Readonly<{}>): preact.ComponentChild
    {
        return null;
    }
}
```

The story here is very similar. The only difference, as previously, is that `mojave.ComponentMountOptions::params`'s type is now the corresponding props-type of the given component. So in the case of `SomePreactFunctionalComponent` the type is `PreactFunctionalProps`, for `SomePreactClassComponent` it's `SomePreactClassComponentProps`.

```typescript
//
// Functional component
//
mountJsx(".foo", SomePreactFunctionalComponent);               // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactFunctionalComponent, { params: {    // no errors -> correct!
    a: "foo",
    b: 42,
}});
mountJsx(".foo", SomePreactFunctionalComponent, { params: {    // errors, too many parameters -> correct!
    a: "foo",
    b: 42,
    asdf: "bla", // unknown additional parameter
}});

//
// Class component
//
mountJsx(".foo", SomePreactClassComponent);                    // no errors -> false positive & known limitation!
mountJsx(".foo", SomePreactClassComponent, { params: {         // no errors -> correct!
    a: "foo",
    b: 42,
}});
mountJsx(".foo", SomePreactClassComponent, { params: {         // errors, too many parameters -> correct!
    a: "foo",
    b: 42,
    asdf: "bla", // unknown additional parameter
}});
```