### PR TITLE
fix automatic secure cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.1.4
+=====
+
+*   **Bugfix**: fix automatic cookie secure setting
+
+
 3.0.5
 =====
 

--- a/cookie.ts
+++ b/cookie.ts
@@ -24,7 +24,7 @@ export function formatCookieString (key : string, value : any, options : CookieO
     let config : {[key: string]: string|boolean} = {
         domain: options.domain || false,
         path: options.path || "/",
-        secure: options.secure || ( window.location.protocol === "https:"),
+        secure: options.secure || (window.location.protocol === "https:"),
     };
 
     // if a Date is given, just use the date.

--- a/cookie.ts
+++ b/cookie.ts
@@ -24,7 +24,7 @@ export function formatCookieString (key : string, value : any, options : CookieO
     let config : {[key: string]: string|boolean} = {
         domain: options.domain || false,
         path: options.path || "/",
-        secure: options.secure || ( window.location.protocol === "https"),
+        secure: options.secure || ( window.location.protocol === "https:"),
     };
 
     // if a Date is given, just use the date.


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                               |
| New feature?  | no                   |
| Improvement?  | yes    |
| BC breaks?    | no                                                                |
| Deprecations? | no    |

Cookies were not set to secure on https due to a typo.
