### PR TITLE
Add onOff()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.1.0
+=====
+
+*   Added `onOff` for easy event use in (preact) hooks.
+
+
 5.0.0
 =====
 

--- a/dom/events.ts
+++ b/dom/events.ts
@@ -106,6 +106,16 @@ export function off<T extends Event = Event> (element : EventHandlerTargets, typ
 
 
 /**
+ * Registers the elements as event listeners and returns a callback that removes the event listener.
+ */
+export function onOff<T extends Event = Event> (element : EventHandlerTargets, type : string|string[], handler : GenericEventListener<T>) : () => void
+{
+    on(element, type, handler);
+    return () => off(element, type, handler);
+}
+
+
+/**
  * Registers an event listener, that is automatically removed after it was executed once.
  *
  * Returns the intermediate function, so that the event listener can be removed:

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -9,6 +9,7 @@ import "../cases/dom/events/delegate";
 import "../cases/dom/events/off";
 import "../cases/dom/events/on";
 import "../cases/dom/events/once";
+import "../cases/dom/events/onOff";
 import "../cases/dom/events/trigger";
 import "../cases/dom/manipulate/after";
 import "../cases/dom/manipulate/append";

--- a/tests/cases/dom/events/onOff.js
+++ b/tests/cases/dom/events/onOff.js
@@ -1,0 +1,30 @@
+import QUnit from "qunit";
+import {onOff, trigger} from "../../../../dom/events";
+
+
+QUnit.module("dom/events/onOff()", {
+    beforeEach ()
+    {
+        document.getElementById("qunit-fixture").innerHTML = `<button type="button" id="button"></button>`;
+    },
+});
+
+
+QUnit.test(
+    "onOff basic functionality",
+    (assert) =>
+    {
+        const done = assert.async(1);
+        assert.expect(1);
+        const element = document.getElementById("button");
+
+        let remove = onOff(element, "click", () => {
+            assert.ok(true, "callback called");
+            done();
+        });
+
+        trigger(element, "click");
+        remove();
+        trigger(element, "click");
+    }
+);


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
This way you can easily use events in Preact hooks:

```js
useEffect(() => {
    return onOff(document, "some-global-event", (event) => {
        // do sth
    });
}, []);
```