### PR TITLE
[v4] Sortable deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.6.1
+=====
+
+*   (bug) Use `MouseEvent.target` instead of `MouseEvent.toElement` in `Sortable`
+
+
 4.6.0
 =====
 

--- a/ui/Sortable.ts
+++ b/ui/Sortable.ts
@@ -164,7 +164,7 @@ export default class Sortable
     private onMouseOut (event : MouseEvent) : void
     {
         const html = findOne("html");
-        if (event.relatedTarget === html && event.toElement === html)
+        if (event.relatedTarget === html && event.target === html)
         {
             this.onDragEnd();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                               |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

Since we haven't locked down v4 on a specific TypeScript version, this may have now broke with a newer TS version. The only useful information I found about this property was in a VS Code issue (see https://github.com/microsoft/vscode/issues/64965), which recommends to use the `.target` property instead of `.toElement`.
