### PR TITLE
Properly reset `z-index` in Sortable after drag

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 | Q             | A
 | ------------- | --------------------------------------------------------------------- |
-| Bug fix?      | yes/no                                                                |
+| BC breaks?    | yes/no                                                                |
 | New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->                   |
 | Improvement?  | yes/no <!-- improves an existing feature, not adding a new one -->    |
-| BC breaks?    | yes/no                                                                |
+| Bug fix?      | yes/no                                                                |
 | Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
 | Docs PR       | **missing** <!-- insert URL here -->                                  |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+next patch
+==========
+
+*   (bug) Properly reset `z-index` in Sortable after drag.
+
+
 5.8.1
 =====
 

--- a/ui/Sortable/SortableInteraction.ts
+++ b/ui/Sortable/SortableInteraction.ts
@@ -416,6 +416,7 @@ export default class SortableInteraction
                                 height: "",
                                 position: "relative",
                                 margin: "",
+                                "z-index": "",
                             });
 
                             setStyles(this.containedIFrames, {


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
