### PR TITLE
Make the `useSortable()` hook more robust against heavily rerendered …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.10.1
+======
+
+*   (bug) Make the `useSortable()` hook more robust against heavily rerendered elements
+
+
 5.10.0
 ======
 

--- a/ui/hooks.ts
+++ b/ui/hooks.ts
@@ -39,5 +39,9 @@ export function useSortable (
         });
 
         return () => sortable.destroy();
-    }, [ref.current, sortableOptions]);
+    }, [ref.current, JSON.stringify(sortableOptions)]);
+    // note, that `useEffect` does a identity comparison. This will fail practically every time, because
+    // the options are normally always newly created in your component. But as the values don't change,
+    // the JSON representation won't change and this way the effect is only called if actually the config
+    // *values* changed.
 }


### PR DESCRIPTION
…elements

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
