### PR TITLE
Add `LocalRouter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+next minor
+==========
+
+*   (feature) Add `LocalRouter`.
+
+
 5.11.1
 ======
 

--- a/kaba.js
+++ b/kaba.js
@@ -5,7 +5,6 @@ module.exports = (new Kaba())
         "all-tests": "tests/build/all-tests.js",
     })
     .setOutputPath("tests/dist")
-    .disableChunkSplitting()
     .disableFileNameHashing()
     .disableModuleConcatenation()
 ;

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
         "mitt": "^1.2.0",
         "preact": "^10.3.4",
         "promise-polyfill": "^8.1.3",
-        "ts-toolbelt": "^4.0.0",
+        "query-string": "^6.12.1",
+        "ts-toolbelt": "^6.8.9",
         "unfetch": "^4.1.0"
     },
     "devDependencies": {
         "@types/qunit": "^2.9.0",
         "browserstack-runner": "^0.9.1",
         "glob": "^7.1.6",
-        "kaba": "^8.1.0",
+        "kaba": "^9.0.0",
         "qunit": "^2.9.2",
         "travis-size-report": "^1.1.0",
         "typescript": "^3.8.3"

--- a/tests/build/all-tests.js
+++ b/tests/build/all-tests.js
@@ -49,6 +49,7 @@ import "../cases/string/manipulate/replaceAll";
 import "../cases/string/manipulate/toStringArray";
 import "../cases/timing/debounce";
 import "../cases/types/typeOf";
+import "../cases/url/router-parameters";
 import "../cases/url/Slug";
 import QUnit from "qunit";
 

--- a/tests/cases/url/router-parameters.js
+++ b/tests/cases/url/router-parameters.js
@@ -1,0 +1,145 @@
+import QUnit from "qunit";
+import {booleanParameter, numberParameter, stringParameter} from "../../../url/router-parameters";
+
+QUnit.module("url/router-parameters");
+
+QUnit.test(
+    "stringParameter() valid cases",
+    (assert) =>
+    {
+        // input, defaultValue, expected
+        const cases = [
+            ["test", null, "test"],
+            [null, null, null],
+            [undefined, null, null],
+            [null, "default", "default"],
+            [undefined, "default", "default"],
+            [123, null, "123"],
+            [123, undefined, "123"],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue, expected]) =>
+            {
+                assert.strictEqual(stringParameter(defaultValue)(input), expected);
+            }
+        );
+    }
+);
+
+QUnit.test(
+    "stringParameter() invalid cases",
+    (assert) =>
+    {
+        // input, defaultValue
+        const cases = [
+            [null, undefined],
+            [undefined, undefined],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue]) =>
+            {
+                assert.throws(() => stringParameter(defaultValue)(input));
+            }
+        );
+    }
+);
+
+QUnit.test(
+    "numberParameter() valid cases",
+    (assert) =>
+    {
+        // input, defaultValue, expected
+        const cases = [
+            [123, null, 123],
+            [123, undefined, 123],
+            ["123", null, 123],
+            ["123", undefined, 123],
+            [null, null, null],
+            [null, 432, 432],
+            [undefined, null, null],
+            [undefined, 432, 432],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue, expected]) =>
+            {
+                assert.strictEqual(numberParameter(defaultValue)(input), expected);
+            }
+        );
+    }
+);
+
+QUnit.test(
+    "numberParameter() invalid cases",
+    (assert) =>
+    {
+        // input, defaultValue
+        const cases = [
+            [null, undefined],
+            [undefined, undefined],
+            ["abc", false],
+            ["abc", true],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue]) =>
+            {
+                assert.throws(() => numberParameter(defaultValue)(input));
+            }
+        );
+    }
+);
+
+QUnit.test(
+    "booleanParameter() valid cases",
+    (assert) =>
+    {
+        // input, defaultValue, expected
+        const cases = [
+            [true, null, true],
+            [false, null, false],
+            ["true", null, true],
+            ["false", null, false],
+            ["true", undefined, true],
+            ["false", undefined, false],
+            ["true", true, true],
+            ["false", true, false],
+            ["true", false, true],
+            ["false", false, false],
+            [undefined, true, true],
+            [undefined, false, false],
+            [null, true, true],
+            [null, false, false],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue, expected]) =>
+            {
+                assert.strictEqual(booleanParameter(defaultValue)(input), expected);
+            }
+        );
+    }
+);
+
+QUnit.test(
+    "booleanParameter() invalid cases",
+    (assert) =>
+    {
+        // input, defaultValue
+        const cases = [
+            ["", undefined],
+            ["test", undefined],
+            // invalid value should always throw
+            ["test", true],
+        ];
+
+        cases.forEach(
+            ([input, defaultValue]) =>
+            {
+                assert.throws(() => booleanParameter(defaultValue)(input));
+            }
+        );
+    }
+);

--- a/tests/index.html
+++ b/tests/index.html
@@ -9,6 +9,6 @@
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>
-        <script src="./dist/js/all-tests.js"></script>
+        <script src="./dist/js/all-tests/legacy/all-tests.js"></script>
     </body>
 </html>

--- a/url/LocalRouter.ts
+++ b/url/LocalRouter.ts
@@ -1,0 +1,221 @@
+import {parse, stringify} from "query-string";
+import { on } from "../dom/events";
+import {extend} from "../extend";
+
+
+export type RouteParams<TParams = Record<string, any>> = TParams;
+
+
+export type RouteHandler<TParams = Record<string, any>> = (params: RouteParams<TParams>) => void;
+
+type RouteParamNormalizers<TRouteParams> = {
+    [TKey in keyof TRouteParams]: ParameterNormalizer<TRouteParams[TKey]>;
+};
+
+export type ParameterNormalizer<Target> = (value: any) => Target;
+
+type RouteDefinition<TRouteParams> = {
+    handler: RouteHandler<TRouteParams>,
+    normalizers: RouteParamNormalizers<TRouteParams>,
+};
+
+
+/**
+ * Normalizes the given params with the given normalizers
+ */
+function normalizeParams (params: RouteParams, normalizers: RouteParamNormalizers<any>) : RouteParams
+{
+    const result: RouteParams = {};
+
+    for (const key in normalizers)
+    {
+        // skip internal param
+        if ("route" === key)
+        {
+            continue;
+        }
+
+        const value = params[key];
+
+        try
+        {
+            result[key] = normalizers[key](value);
+        }
+        catch (e)
+        {
+            throw new Error(`Missing / invalid value for param '${key}': ${e.message}`);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Generates the query string
+ */
+function generateQueryString (route: string, params: RouteParams) : string
+{
+    return "?" + stringify(extend({route}, params), {
+        skipNull: true,
+        skipEmptyString: true,
+        // sort parameters, so that "route" is always the first one
+        sort: (left, right) =>
+        {
+            if (left === "route")
+            {
+                return -1;
+            }
+
+            if (right === "route")
+            {
+                return 1;
+            }
+
+            if (left === right)
+            {
+                return 0;
+            }
+
+            return left < right ? -1 : 1;
+        },
+    });
+}
+
+/**
+ * Parses the current query parameters
+ */
+function parseQueryString (queryString: string) : RouteParams
+{
+    return parse(queryString, {parseNumbers: true}) as RouteParams;
+}
+
+
+/**
+ * A local router that uses URL query parameters for routing
+ */
+export class LocalRouter
+{
+    private collection: Record<string, RouteDefinition<any>> = {};
+    private useUrl: boolean;
+
+
+    /**
+     */
+    public constructor (updateUrl: boolean = true)
+    {
+        this.useUrl = updateUrl;
+    }
+
+
+    /**
+     * Registers a new route handler
+     */
+    public on <TRouteParams> (
+        name: string,
+        handler: RouteHandler<TRouteParams>,
+        normalizers: RouteParamNormalizers<TRouteParams>
+    ) : this
+    {
+        if (this.collection[name])
+        {
+            throw new Error("Can't define two routes with the same name.");
+        }
+
+        if ("route" in normalizers)
+        {
+            throw new Error("Can't use 'route' as route parameter");
+        }
+
+        this.collection[name] = {handler, normalizers};
+
+        return this;
+    }
+
+
+    /**
+     * Initializes the router
+     */
+    public init (fallbackRoute: string, fallbackParams: RouteParams = {}) : void
+    {
+        const fallback = this.collection[fallbackRoute];
+
+        // fail early, to always catch the error, even in early exit
+        if (!fallback)
+        {
+            throw new Error(`Invalid initialization: there is no route named '${fallbackRoute}'`);
+        }
+
+        if (this.useUrl)
+        {
+            // register event listener
+            on(window, "popstate", () => this.match(document.location.search));
+
+            // try to match
+            if (this.match(document.location.search))
+            {
+                return;
+            }
+        }
+
+        fallback.handler(normalizeParams(fallbackParams, fallback.normalizers));
+    }
+
+
+    /**
+     * Navigates to the given route
+     */
+    public navigate (route: string, params: RouteParams = {}): void
+    {
+        const definition = this.collection[route];
+
+        if (!definition)
+        {
+            throw new Error(`Route not found: ${route}`);
+        }
+
+        // let the exception bubble through
+        const normalized = normalizeParams(params, definition.normalizers);
+        definition.handler(normalized);
+
+        if (this.useUrl && normalized)
+        {
+            window.history.pushState(
+                params,
+                document.title,
+                generateQueryString(route, normalized)
+            );
+        }
+    }
+
+
+    /**
+     * Tries to match the query string
+     */
+    private match (queryString: string) : boolean
+    {
+        const params = parseQueryString(queryString);
+        const route = params.route;
+
+        if (typeof route !== "string")
+        {
+            return false;
+        }
+
+        const definition = this.collection[route];
+
+        if (!definition)
+        {
+            return false;
+        }
+
+        try
+        {
+            definition.handler(normalizeParams(params, definition.normalizers));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/url/router-parameters.ts
+++ b/url/router-parameters.ts
@@ -1,0 +1,93 @@
+import {ParameterNormalizer} from "./LocalRouter";
+
+
+/**
+ * Generates a default type error
+ *
+ * @internal
+ */
+function typeError (expected: string, value: any): never
+{
+    throw new Error(
+        undefined === value
+            ? `Missing parameter, expected ${expected}`
+            : `Can't parse value as ${expected}: '${value}'`
+    );
+}
+
+
+/**
+ * Normalizes the value as string.
+ *
+ * A missing default means this value is always required.
+ */
+export function stringParameter (defaultValue?: string) : ParameterNormalizer<string>
+{
+    return (value: any) =>
+    {
+        if (null == value)
+        {
+            return defaultValue === undefined
+                ? typeError("string", value)
+                : defaultValue;
+        }
+
+        return "" + value;
+    };
+}
+
+/**
+ * Normalizes the value as number.
+ *
+ * A missing default means this value is always required.
+ */
+export function numberParameter (defaultValue?: number) : ParameterNormalizer<number>
+{
+    return (value: any) =>
+    {
+        if (typeof value === "number")
+        {
+            return value;
+        }
+
+        const parsed = parseInt(value, 10);
+
+        if (!isNaN(parsed))
+        {
+            return parsed;
+        }
+
+        // throw if required or invalid (non-empty) value given
+        return (defaultValue === undefined || null != value)
+            ? typeError("number", value)
+            : defaultValue;
+    };
+}
+
+/**
+ * Normalizes the value as boolean.
+ *
+ * A missing default means this value is always required.
+ */
+export function booleanParameter (defaultValue?: boolean) : ParameterNormalizer<boolean>
+{
+    return (value: any) =>
+    {
+        if (typeof value == "boolean")
+        {
+            return value;
+        }
+
+        const isTrue = "true" === value;
+
+        if ("false" === value || isTrue)
+        {
+            return isTrue;
+        }
+
+        // throw if required or invalid (non-empty) value given
+        return (defaultValue === undefined || null != value)
+            ? typeError("boolean", value)
+            : defaultValue;
+    };
+}


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->

This PR adds a generic local router, that handles on-page navigation using query params. It is indeed just called with the generic name "local router", as most realistically this is the only place where such a router is used, and in such cases this router should be enough.

It is used like this:

```js
import {LocalRouter} from "mojave/url/LocalRouter";
import {stringParameter, numberParameter, booleanParameter} from "mojave/url/router-parameters";


const router = new LocalRouter();

router
    // register your routes with name, handler and param normalizers
    // there is a list of predefined param normalizers. They are supposed to receive the param with the given name
    // and return either the normalized version in the right type, or throw an error
    .on(
	    "list", 
        param => this.handleList(param.page, param.query),
        {
            page: numberParameter(),
            query: stringParameter(""),
        }
    )
    .on(
        "add",
        () => this.addAction(),
        {}
    )
    .on<{id: number}>(
        "edit",
        params => this.editAction(params.id),
        {
            id: numberParameter(),
            someFlag: booleanParameter(true),
        }
    )
    // initialize the router
    .init("list", {page: 1});


router.navigate("edit", {id: 5});
```

So, you basically define routes, their handlers and how the parameters are normalized. The parameter normalization can fail:

* in case of route match it just won't be a match
* in case of `.navigate()` it will throw an error (as it is a bug basically).

We have proper type support in `.on()`, unfortunately in the case of `.navigate()` we don't have TypeScript support, as the types are lost at this point (you can't statically have a dynamic indexed type list). But the call will – thanks to the normalizers – be properly normalized + error checked at runtime (which is important, as there are a lot of user-provided values involved).

The normalizers are pretty simple functions. They receive the raw value and either transform it (if possible) or just throw an error.

*Edit* Refactored:
so now we also have proper sanitation in `.init()` and `.navigate()`, by refactoring the parameters.

They are now a function, that takes an optional default value and return a function that parses the given value:

* If the given value is valid, use it.
* If the given value is invalid (or missing) and there is a default, use the default value (= optional parameter)
* If the given value is invalid (or missing) and there is NO default value, throw.

So, to reiterate:

* passing a default: optional parameter
* no default: required parameter

This simplification / refactoring enables us to properly fill incomplete `.init()` and `.navigate()` calls (like above) with the default values. Also the initializers are now strictly type safe.

The normalizers were also extended to pass values in the correct type straight through. This enables us to have REAL type safety even in `.init()` and `.navigate()`.

I also added an early check if the `fallbackRoute` in `.init()` isn't defined.


Supersedes and closes #265