### PR TITLE
Use `lax` as default `Same-Site` for cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ next patch
 ==========
 
 *   (bug) Prevent issues with cookie names containing a `.`.
+*   (improvement) Use `lax` as default `Same-Site` for cookies.
 
 
 5.12.0

--- a/cookie.ts
+++ b/cookie.ts
@@ -30,7 +30,7 @@ export function formatCookieString (key : string, value : any, options : CookieO
         domain: options.domain || false,
         path: options.path || "/",
         secure: options.secure || (window.location.protocol === "https:"),
-        sameSite: options.sameSite !== undefined ? options.sameSite : "strict",
+        sameSite: options.sameSite !== undefined ? options.sameSite : "lax",
     };
 
     // if a Date is given, just use the date.

--- a/tests/cases/cookie/formatCookieString.js
+++ b/tests/cases/cookie/formatCookieString.js
@@ -14,7 +14,7 @@ QUnit.test(
                 key: 'test',
                 value: 'value',
                 options: {},
-                expected: /^test=%22value%22;path=\/ ;sameSite=strict ;expires=/,
+                expected: /^test=%22value%22;path=\/ ;sameSite=lax ;expires=/,
             },
 
             // explicitly secure + insecure test
@@ -24,7 +24,7 @@ QUnit.test(
                 options: {
                     secure: true,
                 },
-                expected: /^test=%22value%22;path=\/ ;secure ;sameSite=strict ;expires=/,
+                expected: /^test=%22value%22;path=\/ ;secure ;sameSite=lax ;expires=/,
             },
             {
                 key: 'test',
@@ -32,15 +32,15 @@ QUnit.test(
                 options: {
                     secure: false,
                 },
-                expected: /^test=%22value%22;path=\/ ;sameSite=strict ;expires=/,
+                expected: /^test=%22value%22;path=\/ ;sameSite=lax ;expires=/,
             },
             {
                 key: 'test',
                 value: 'value',
                 options: {
-                    sameSite: "lax",
+                    sameSite: "strict",
                 },
-                expected: /^test=%22value%22;path=\/ ;sameSite=lax ;expires=/,
+                expected: /^test=%22value%22;path=\/ ;sameSite=strict ;expires=/,
             },
             {
                 key: 'test',


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | no                                                                |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
