### PR TITLE
`LocalRouter` must keep existing query parameters to not break any pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.17.4
+======
+
+*   (bug) `LocalRouter` must keep existing query parameters to not break any pages.
+
+
 5.17.3
 ======
 

--- a/url/LocalRouter.ts
+++ b/url/LocalRouter.ts
@@ -1,5 +1,5 @@
 import {parse, stringify} from "query-string";
-import { on } from "../dom/events";
+import {on} from "../dom/events";
 import {extend} from "../extend";
 
 
@@ -55,7 +55,10 @@ function normalizeParams (params: RouteParams, normalizers: RouteParamNormalizer
  */
 function generateQueryString (route: string, params: RouteParams) : string
 {
-    return "?" + stringify(extend({route}, params), {
+    // keep all existing parameters and only overwrite the known ones
+    const existingParameters = parseQueryString(document.location.search);
+
+    return "?" + stringify(extend(existingParameters, {route}, params), {
         skipNull: true,
         skipEmptyString: true,
         // sort parameters, so that "route" is always the first one


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
